### PR TITLE
Combine versions into a single artifact

### DIFF
--- a/generator/src/googleapis/codegen/api_library_generator.py
+++ b/generator/src/googleapis/codegen/api_library_generator.py
@@ -50,6 +50,8 @@ class ApiLibraryGenerator(TemplateGenerator):
       discovery['modulePath'] = module_path
     if options.get('version_package'):
       discovery['version_module'] = True
+    if options.get('package_revision'):
+      discovery['revision'] = options.get('package_revision')
     self._api = api_loader(discovery)
     self._language = language
 

--- a/generator/src/googleapis/codegen/generate_library.py
+++ b/generator/src/googleapis/codegen/generate_library.py
@@ -106,6 +106,11 @@ flags.DEFINE_string(
     'Use an alternate path for the generated code. This must be a file path'
     ' using "/" as a separator, not "."'
     )
+flags.DEFINE_string(
+    'package_revision',
+    None,
+    'Override the revision for the generated code.'
+    )
 flags.DEFINE_bool('version_package', False, 'Put API version in package paths')
 flags.DEFINE_bool('verbose', False, 'Enable verbose logging')
 
@@ -164,7 +169,8 @@ def main(unused_argv):
            package_path=FLAGS.package_path,
            output_type=FLAGS.output_type,
            language=FLAGS.language,
-           language_variant=FLAGS.language_variant)
+           language_variant=FLAGS.language_variant,
+           package_revision=FLAGS.package_revision)
   return 0
 
 
@@ -172,6 +178,7 @@ def Generate(discovery_doc, package_writer,
              include_timestamp=False,
              version_package=False,
              package_path=None,
+             package_revision=None,
              output_type='plain',
              language='java',
              language_variant='default',
@@ -186,6 +193,7 @@ def Generate(discovery_doc, package_writer,
       'version_package': version_package,
       # Custom package name
       'package_path': package_path,
+      'package_revision': package_revision,
       }
   if FLAGS.monolithic_source_name:
     options['useSingleSourceFile'] = True
@@ -223,6 +231,7 @@ def Generate(discovery_doc, package_writer,
              include_timestamp=include_timestamp,
              version_package=version_package,
              package_path=package_path,
+             package_revision=package_revision,
              output_type=output_type,
              language=language,
              language_variant=language_variant)

--- a/generator/src/googleapis/codegen/utilities/maven_utils.py
+++ b/generator/src/googleapis/codegen/utilities/maven_utils.py
@@ -64,10 +64,9 @@ def GetMavenGroupId(owner_domain):
 def GetMavenVersion(api, language_version):
   """Returns the maven version."""
   if api.get('ownerDomain') == 'google.com':
-    return '%s-rev%s-%s' %(api['version'],
-                           api['revision'],
-                           language_version)
-  return '%s-%s-SNAPSHOT' % (api['version'], language_version)
+    return 'rev%s-%s' %(api['revision'],
+                        language_version)
+  return '%s-SNAPSHOT' % (language_version)
 
 
 def GetMavenMetadata(api, language_version):


### PR DESCRIPTION
Fixes #447
Unblocks #490

This would cause a breaking change in that the generated class namespaces would include the API version. For example `com.google.api.services.adexchangebuyer.AdExchangeBuyer` would change to `com.google.api.services.adexchangebuyer.v1_4.AdExchangeBuyer`. This allows a user to install multiple API versions of the same API.

This breaking change affects the following libraries:
* adexchangebuyer
* adsense
* adsensehost
* analytics
* androidenterprise
* androidpublisher
* appsactivity
* appstate
* bigquery
* blogger
* books
* calendar
* civicinfo
* classroom
* cloudresourcemanager
* compute
* container
* content
* customsearch
* dataflow
* dataproc
* deploymentmanager
* dfareporting
* discovery
* dns
* doubleclickbidmanager
* doubleclicksearch
* drive
* fitness
* fusiontables
* games
* games-configuration
* games-management
* genomics
* gmail
* groupsmigration
* groupssettings
* identitytoolkit
* licensing
* mirror
* oauth2
* pagespeedonline
* playcustomapp
* plus
* plus-domains
* pubsub
* replicapool
* replicapoolupdater
* reseller
* safebrowsing
* script
* servicemanagement
* site-verification
* sqladmin
* storage
* surveys
* tagmanager
* tasks
* testing
* toolresults
* translate
* urlshortener
* webfonts
* webmasters
* youtube
* youtube-analytics
* youtubereporting