### PR TITLE
Fix Proguard hack thrashing during codegen

### DIFF
--- a/generator/src/googleapis/codegen/api.py
+++ b/generator/src/googleapis/codegen/api.py
@@ -222,7 +222,6 @@ class Api(template_objects.CodeObject):
     schemas = self.values.get('schemas')
     if schemas:
       for name in sorted(schemas):
-        print(name)
         def_dict = schemas[name]
         # Upgrade the string format schema to a dict.
         if isinstance(def_dict, unicode):

--- a/generator/src/googleapis/codegen/api.py
+++ b/generator/src/googleapis/codegen/api.py
@@ -221,7 +221,9 @@ class Api(template_objects.CodeObject):
     """Loop over the schemas in the discovery doc and build definitions."""
     schemas = self.values.get('schemas')
     if schemas:
-      for name, def_dict in schemas.iteritems():
+      for name in sorted(schemas):
+        print(name)
+        def_dict = schemas[name]
         # Upgrade the string format schema to a dict.
         if isinstance(def_dict, unicode):
           def_dict = json.loads(def_dict)


### PR DESCRIPTION
Always process schemas in alphabetical order.

This allows the schema reference algorithm to be consistent and avoids
the Proguard hack thrashing.

Fixes #51 

We will want to rebuild all the clients after the PR to avoid having 100+ PRs from autosynth fixing the order.