### PR TITLE
Provide a copy of the discovery document as a resource

### DIFF
--- a/generator/src/googleapis/codegen/languages/java/1.26.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.26.0/templates/_pom_xml.tmpl
@@ -82,6 +82,11 @@
       </plugin>
     </plugins>
     <sourceDirectory>{% if layout.unzip_source %}{{ layout.source_location }}{% else %}.{% endif %}</sourceDirectory>
+    <resources>
+      <resource>
+        <directory>./resources</directory>
+      </resource>
+    </resources>
   </build>
 
   <dependencies>

--- a/generator/src/googleapis/codegen/languages/java/1.27.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.27.0/templates/_pom_xml.tmpl
@@ -82,6 +82,11 @@
       </plugin>
     </plugins>
     <sourceDirectory>{% if layout.unzip_source %}{{ layout.source_location }}{% else %}.{% endif %}</sourceDirectory>
+    <resources>
+      <resource>
+        <directory>./resources</directory>
+      </resource>
+    </resources>
   </build>
 
   <dependencies>

--- a/generator/src/googleapis/codegen/languages/java/default/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/default/templates/_pom_xml.tmpl
@@ -82,6 +82,11 @@
       </plugin>
     </plugins>
     <sourceDirectory>{% if layout.unzip_source %}{{ layout.source_location }}{% else %}.{% endif %}</sourceDirectory>
+    <resources>
+      <resource>
+        <directory>./resources</directory>
+      </resource>
+    </resources>
   </build>
 
   <dependencies>

--- a/synth.py
+++ b/synth.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import glob
 import re
 import sys
+import shutil
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -81,6 +82,10 @@ def generate_service(disco: str):
         shell.run(command.split(), cwd=repository)
 
         s.copy(output_dir, f"clients/{template}/{library_name}/{version}")
+
+        resource_dir = repository / "clients" / template / library_name / version / "resources"
+        shell.run(f"mkdir -p {resource_dir}".split())
+        shutil.copy(input_file, resource_dir / path.basename(disco))
 
 
 def all_discoveries():


### PR DESCRIPTION
At codegen time, we copy the discovery document to the resources folder. This folder is now configured to be included as a resource in the resulting jar.

We will want to regenerate all the clients after merging.