### PR TITLE
Allow $ in model field names

### DIFF
--- a/generator/src/googleapis/codegen/utilities/name_validator.py
+++ b/generator/src/googleapis/codegen/utilities/name_validator.py
@@ -30,7 +30,7 @@ import re
 # (.) or dash (-).  NOTE: the '$' character is to get around $ref
 # variable name in some APIs.
 _VARNAME_REGEX = re.compile(
-    r'^[a-zA-Z]$|([a-zA-Z_/$@][a-zA-Z0-9_./-]+)$')
+    r'^[a-zA-Z]$|([a-zA-Z_/$@][a-zA-Z0-9_./$-]+)$')
 
 _API_NAME_REGEX = re.compile(r'[a-z][a-zA-Z0-9_]*$')
 _API_VERSION_REGEX = re.compile(r'[a-z0-9][a-zA-Z0-9._-]*$')

--- a/generator/tests/utilities/name_validator_test.py
+++ b/generator/tests/utilities/name_validator_test.py
@@ -29,7 +29,7 @@ class NameValidatorTest(basetest.TestCase):
   def testVariableNameValidator(self):
     good_names = ['$ref', '_a', '_private', 'a_var.name', 't1', 'max-results',
                   'slashes/are/allowed', '/even/at/the/start/and/end/',
-                  'now_valid.', '@foo']
+                  'now_valid.', '@foo', 'foo$bar']
     bad_names = ['$', '1st_result', '^test', '.variable', '1', '_', 'no spaces',
                  'foo@']
 


### PR DESCRIPTION
Allows `$` in the middle of parameter names to enable an upcoming API release.