### PR TITLE
Fix doc uploader service name

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -56,7 +56,7 @@ deploy_library() {
 
   # create metadata
   python3 -m docuploader create-metadata \
-    --name ${SERVICE} \
+    --name google-api-services-${SERVICE} \
     --version ${API_VERSION}-${REVISION}-${LIBRARY_VERSION} \
     --language java
 


### PR DESCRIPTION
The docs should be uploaded as google-api-services-x rather than just x.