### PR TITLE
Add metadata file

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -108,7 +108,7 @@ def generate_service(disco: str):
     }
     metadata_file = repository / "metadata" / f"{library_name}.json"
     with open(metadata_file, "w") as outfile:
-        json.dump(metadata, outfile)
+        json.dump(metadata, outfile, indent=2)
 
 
 def all_discoveries():


### PR DESCRIPTION
This will be used for the devsite documentation that suggests which version to install. The javascript currently points to the legacy code generator.

Example: https://developers.google.com/api-client-library/java/apis/books/v1