### PR TITLE
Fix javadocs

### DIFF
--- a/clients/google-api-services-abusiveexperiencereport/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-abusiveexperiencereport/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Abusive Experience Report API ${project.version}</doctitle>
           <windowtitle>Abusive Experience Report API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-abusiveexperiencereport/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-abusiveexperiencereport/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Abusive Experience Report API ${project.version}</doctitle>
           <windowtitle>Abusive Experience Report API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-abusiveexperiencereport/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-abusiveexperiencereport/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Abusive Experience Report API ${project.version}</doctitle>
           <windowtitle>Abusive Experience Report API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-acceleratedmobilepageurl/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-acceleratedmobilepageurl/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Accelerated Mobile Pages (AMP) URL API ${project.version}</doctitle>
           <windowtitle>Accelerated Mobile Pages (AMP) URL API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-acceleratedmobilepageurl/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-acceleratedmobilepageurl/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Accelerated Mobile Pages (AMP) URL API ${project.version}</doctitle>
           <windowtitle>Accelerated Mobile Pages (AMP) URL API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-acceleratedmobilepageurl/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-acceleratedmobilepageurl/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Accelerated Mobile Pages (AMP) URL API ${project.version}</doctitle>
           <windowtitle>Accelerated Mobile Pages (AMP) URL API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-accessapproval/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-accessapproval/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Access Approval API ${project.version}</doctitle>
           <windowtitle>Access Approval API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-accessapproval/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-accessapproval/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Access Approval API ${project.version}</doctitle>
           <windowtitle>Access Approval API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-accessapproval/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-accessapproval/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Access Approval API ${project.version}</doctitle>
           <windowtitle>Access Approval API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-accesscontextmanager/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-accesscontextmanager/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Access Context Manager API ${project.version}</doctitle>
           <windowtitle>Access Context Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-accesscontextmanager/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-accesscontextmanager/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Access Context Manager API ${project.version}</doctitle>
           <windowtitle>Access Context Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-accesscontextmanager/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-accesscontextmanager/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Access Context Manager API ${project.version}</doctitle>
           <windowtitle>Access Context Manager API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-accesscontextmanager/v1beta/1.26.0/pom.xml
+++ b/clients/google-api-services-accesscontextmanager/v1beta/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Access Context Manager API ${project.version}</doctitle>
           <windowtitle>Access Context Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-accesscontextmanager/v1beta/1.27.0/pom.xml
+++ b/clients/google-api-services-accesscontextmanager/v1beta/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Access Context Manager API ${project.version}</doctitle>
           <windowtitle>Access Context Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-accesscontextmanager/v1beta/1.28.0/pom.xml
+++ b/clients/google-api-services-accesscontextmanager/v1beta/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Access Context Manager API ${project.version}</doctitle>
           <windowtitle>Access Context Manager API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adexchangebuyer/v1.2/1.26.0/pom.xml
+++ b/clients/google-api-services-adexchangebuyer/v1.2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Ad Exchange Buyer API ${project.version}</doctitle>
           <windowtitle>Ad Exchange Buyer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adexchangebuyer/v1.2/1.27.0/pom.xml
+++ b/clients/google-api-services-adexchangebuyer/v1.2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Ad Exchange Buyer API ${project.version}</doctitle>
           <windowtitle>Ad Exchange Buyer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adexchangebuyer/v1.2/1.28.0/pom.xml
+++ b/clients/google-api-services-adexchangebuyer/v1.2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Ad Exchange Buyer API ${project.version}</doctitle>
           <windowtitle>Ad Exchange Buyer API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adexchangebuyer/v1.3/1.26.0/pom.xml
+++ b/clients/google-api-services-adexchangebuyer/v1.3/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Ad Exchange Buyer API ${project.version}</doctitle>
           <windowtitle>Ad Exchange Buyer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adexchangebuyer/v1.3/1.27.0/pom.xml
+++ b/clients/google-api-services-adexchangebuyer/v1.3/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Ad Exchange Buyer API ${project.version}</doctitle>
           <windowtitle>Ad Exchange Buyer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adexchangebuyer/v1.3/1.28.0/pom.xml
+++ b/clients/google-api-services-adexchangebuyer/v1.3/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Ad Exchange Buyer API ${project.version}</doctitle>
           <windowtitle>Ad Exchange Buyer API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adexchangebuyer/v1.4/1.26.0/pom.xml
+++ b/clients/google-api-services-adexchangebuyer/v1.4/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Ad Exchange Buyer API ${project.version}</doctitle>
           <windowtitle>Ad Exchange Buyer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adexchangebuyer/v1.4/1.27.0/pom.xml
+++ b/clients/google-api-services-adexchangebuyer/v1.4/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Ad Exchange Buyer API ${project.version}</doctitle>
           <windowtitle>Ad Exchange Buyer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adexchangebuyer/v1.4/1.28.0/pom.xml
+++ b/clients/google-api-services-adexchangebuyer/v1.4/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Ad Exchange Buyer API ${project.version}</doctitle>
           <windowtitle>Ad Exchange Buyer API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adexchangebuyer2/v2beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-adexchangebuyer2/v2beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Ad Exchange Buyer API II ${project.version}</doctitle>
           <windowtitle>Ad Exchange Buyer API II ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adexchangebuyer2/v2beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-adexchangebuyer2/v2beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Ad Exchange Buyer API II ${project.version}</doctitle>
           <windowtitle>Ad Exchange Buyer API II ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adexchangebuyer2/v2beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-adexchangebuyer2/v2beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Ad Exchange Buyer API II ${project.version}</doctitle>
           <windowtitle>Ad Exchange Buyer API II ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adexperiencereport/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-adexperiencereport/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Ad Experience Report API ${project.version}</doctitle>
           <windowtitle>Ad Experience Report API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adexperiencereport/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-adexperiencereport/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Ad Experience Report API ${project.version}</doctitle>
           <windowtitle>Ad Experience Report API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adexperiencereport/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-adexperiencereport/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Ad Experience Report API ${project.version}</doctitle>
           <windowtitle>Ad Experience Report API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adsense/v1.4/1.26.0/pom.xml
+++ b/clients/google-api-services-adsense/v1.4/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>AdSense Management API ${project.version}</doctitle>
           <windowtitle>AdSense Management API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adsense/v1.4/1.27.0/pom.xml
+++ b/clients/google-api-services-adsense/v1.4/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>AdSense Management API ${project.version}</doctitle>
           <windowtitle>AdSense Management API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adsense/v1.4/1.28.0/pom.xml
+++ b/clients/google-api-services-adsense/v1.4/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>AdSense Management API ${project.version}</doctitle>
           <windowtitle>AdSense Management API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adsensehost/v4.1/1.26.0/pom.xml
+++ b/clients/google-api-services-adsensehost/v4.1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>AdSense Host API ${project.version}</doctitle>
           <windowtitle>AdSense Host API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adsensehost/v4.1/1.27.0/pom.xml
+++ b/clients/google-api-services-adsensehost/v4.1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>AdSense Host API ${project.version}</doctitle>
           <windowtitle>AdSense Host API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-adsensehost/v4.1/1.28.0/pom.xml
+++ b/clients/google-api-services-adsensehost/v4.1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>AdSense Host API ${project.version}</doctitle>
           <windowtitle>AdSense Host API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-alertcenter/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-alertcenter/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>G Suite Alert Center API ${project.version}</doctitle>
           <windowtitle>G Suite Alert Center API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-alertcenter/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-alertcenter/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>G Suite Alert Center API ${project.version}</doctitle>
           <windowtitle>G Suite Alert Center API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-alertcenter/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-alertcenter/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>G Suite Alert Center API ${project.version}</doctitle>
           <windowtitle>G Suite Alert Center API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-analyticsreporting/v4/1.26.0/pom.xml
+++ b/clients/google-api-services-analyticsreporting/v4/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Analytics Reporting API ${project.version}</doctitle>
           <windowtitle>Analytics Reporting API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-analyticsreporting/v4/1.27.0/pom.xml
+++ b/clients/google-api-services-analyticsreporting/v4/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Analytics Reporting API ${project.version}</doctitle>
           <windowtitle>Analytics Reporting API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-analyticsreporting/v4/1.28.0/pom.xml
+++ b/clients/google-api-services-analyticsreporting/v4/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Analytics Reporting API ${project.version}</doctitle>
           <windowtitle>Analytics Reporting API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androiddeviceprovisioning/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-androiddeviceprovisioning/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Android Device Provisioning Partner API ${project.version}</doctitle>
           <windowtitle>Android Device Provisioning Partner API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androiddeviceprovisioning/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-androiddeviceprovisioning/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Android Device Provisioning Partner API ${project.version}</doctitle>
           <windowtitle>Android Device Provisioning Partner API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androiddeviceprovisioning/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-androiddeviceprovisioning/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Android Device Provisioning Partner API ${project.version}</doctitle>
           <windowtitle>Android Device Provisioning Partner API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidenterprise/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-androidenterprise/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play EMM API ${project.version}</doctitle>
           <windowtitle>Google Play EMM API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidenterprise/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-androidenterprise/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play EMM API ${project.version}</doctitle>
           <windowtitle>Google Play EMM API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidenterprise/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-androidenterprise/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play EMM API ${project.version}</doctitle>
           <windowtitle>Google Play EMM API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidmanagement/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-androidmanagement/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Android Management API ${project.version}</doctitle>
           <windowtitle>Android Management API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidmanagement/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-androidmanagement/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Android Management API ${project.version}</doctitle>
           <windowtitle>Android Management API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidmanagement/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-androidmanagement/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Android Management API ${project.version}</doctitle>
           <windowtitle>Android Management API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidpublisher/v1.1/1.26.0/pom.xml
+++ b/clients/google-api-services-androidpublisher/v1.1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Developer API ${project.version}</doctitle>
           <windowtitle>Google Play Developer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidpublisher/v1.1/1.27.0/pom.xml
+++ b/clients/google-api-services-androidpublisher/v1.1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Developer API ${project.version}</doctitle>
           <windowtitle>Google Play Developer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidpublisher/v1.1/1.28.0/pom.xml
+++ b/clients/google-api-services-androidpublisher/v1.1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Developer API ${project.version}</doctitle>
           <windowtitle>Google Play Developer API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidpublisher/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-androidpublisher/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Developer API ${project.version}</doctitle>
           <windowtitle>Google Play Developer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidpublisher/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-androidpublisher/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Developer API ${project.version}</doctitle>
           <windowtitle>Google Play Developer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidpublisher/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-androidpublisher/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Developer API ${project.version}</doctitle>
           <windowtitle>Google Play Developer API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidpublisher/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-androidpublisher/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Developer API ${project.version}</doctitle>
           <windowtitle>Google Play Developer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidpublisher/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-androidpublisher/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Developer API ${project.version}</doctitle>
           <windowtitle>Google Play Developer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidpublisher/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-androidpublisher/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Developer API ${project.version}</doctitle>
           <windowtitle>Google Play Developer API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidpublisher/v3/1.26.0/pom.xml
+++ b/clients/google-api-services-androidpublisher/v3/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Developer API ${project.version}</doctitle>
           <windowtitle>Google Play Developer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidpublisher/v3/1.27.0/pom.xml
+++ b/clients/google-api-services-androidpublisher/v3/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Developer API ${project.version}</doctitle>
           <windowtitle>Google Play Developer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-androidpublisher/v3/1.28.0/pom.xml
+++ b/clients/google-api-services-androidpublisher/v3/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Developer API ${project.version}</doctitle>
           <windowtitle>Google Play Developer API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appengine/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-appengine/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>App Engine Admin API ${project.version}</doctitle>
           <windowtitle>App Engine Admin API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appengine/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-appengine/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>App Engine Admin API ${project.version}</doctitle>
           <windowtitle>App Engine Admin API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appengine/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-appengine/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>App Engine Admin API ${project.version}</doctitle>
           <windowtitle>App Engine Admin API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appengine/v1alpha/1.26.0/pom.xml
+++ b/clients/google-api-services-appengine/v1alpha/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>App Engine Admin API ${project.version}</doctitle>
           <windowtitle>App Engine Admin API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appengine/v1alpha/1.27.0/pom.xml
+++ b/clients/google-api-services-appengine/v1alpha/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>App Engine Admin API ${project.version}</doctitle>
           <windowtitle>App Engine Admin API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appengine/v1alpha/1.28.0/pom.xml
+++ b/clients/google-api-services-appengine/v1alpha/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>App Engine Admin API ${project.version}</doctitle>
           <windowtitle>App Engine Admin API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appengine/v1beta/1.26.0/pom.xml
+++ b/clients/google-api-services-appengine/v1beta/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>App Engine Admin API ${project.version}</doctitle>
           <windowtitle>App Engine Admin API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appengine/v1beta/1.27.0/pom.xml
+++ b/clients/google-api-services-appengine/v1beta/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>App Engine Admin API ${project.version}</doctitle>
           <windowtitle>App Engine Admin API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appengine/v1beta/1.28.0/pom.xml
+++ b/clients/google-api-services-appengine/v1beta/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>App Engine Admin API ${project.version}</doctitle>
           <windowtitle>App Engine Admin API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appengine/v1beta4/1.26.0/pom.xml
+++ b/clients/google-api-services-appengine/v1beta4/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>App Engine Admin API ${project.version}</doctitle>
           <windowtitle>App Engine Admin API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appengine/v1beta4/1.27.0/pom.xml
+++ b/clients/google-api-services-appengine/v1beta4/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>App Engine Admin API ${project.version}</doctitle>
           <windowtitle>App Engine Admin API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appengine/v1beta4/1.28.0/pom.xml
+++ b/clients/google-api-services-appengine/v1beta4/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>App Engine Admin API ${project.version}</doctitle>
           <windowtitle>App Engine Admin API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appengine/v1beta5/1.26.0/pom.xml
+++ b/clients/google-api-services-appengine/v1beta5/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>App Engine Admin API ${project.version}</doctitle>
           <windowtitle>App Engine Admin API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appengine/v1beta5/1.27.0/pom.xml
+++ b/clients/google-api-services-appengine/v1beta5/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>App Engine Admin API ${project.version}</doctitle>
           <windowtitle>App Engine Admin API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appengine/v1beta5/1.28.0/pom.xml
+++ b/clients/google-api-services-appengine/v1beta5/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>App Engine Admin API ${project.version}</doctitle>
           <windowtitle>App Engine Admin API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appsactivity/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-appsactivity/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Drive Activity API ${project.version}</doctitle>
           <windowtitle>Drive Activity API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appsactivity/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-appsactivity/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Drive Activity API ${project.version}</doctitle>
           <windowtitle>Drive Activity API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appsactivity/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-appsactivity/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Drive Activity API ${project.version}</doctitle>
           <windowtitle>Drive Activity API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appstate/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-appstate/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google App State API ${project.version}</doctitle>
           <windowtitle>Google App State API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appstate/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-appstate/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google App State API ${project.version}</doctitle>
           <windowtitle>Google App State API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-appstate/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-appstate/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google App State API ${project.version}</doctitle>
           <windowtitle>Google App State API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-bigquery/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-bigquery/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>BigQuery API ${project.version}</doctitle>
           <windowtitle>BigQuery API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-bigquery/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-bigquery/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>BigQuery API ${project.version}</doctitle>
           <windowtitle>BigQuery API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-bigquery/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-bigquery/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>BigQuery API ${project.version}</doctitle>
           <windowtitle>BigQuery API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-binaryauthorization/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-binaryauthorization/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Binary Authorization API ${project.version}</doctitle>
           <windowtitle>Binary Authorization API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-binaryauthorization/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-binaryauthorization/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Binary Authorization API ${project.version}</doctitle>
           <windowtitle>Binary Authorization API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-binaryauthorization/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-binaryauthorization/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Binary Authorization API ${project.version}</doctitle>
           <windowtitle>Binary Authorization API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-blogger/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-blogger/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Blogger API ${project.version}</doctitle>
           <windowtitle>Blogger API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-blogger/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-blogger/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Blogger API ${project.version}</doctitle>
           <windowtitle>Blogger API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-blogger/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-blogger/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Blogger API ${project.version}</doctitle>
           <windowtitle>Blogger API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-blogger/v3/1.26.0/pom.xml
+++ b/clients/google-api-services-blogger/v3/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Blogger API ${project.version}</doctitle>
           <windowtitle>Blogger API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-blogger/v3/1.27.0/pom.xml
+++ b/clients/google-api-services-blogger/v3/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Blogger API ${project.version}</doctitle>
           <windowtitle>Blogger API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-blogger/v3/1.28.0/pom.xml
+++ b/clients/google-api-services-blogger/v3/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Blogger API ${project.version}</doctitle>
           <windowtitle>Blogger API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-books/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-books/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Books API ${project.version}</doctitle>
           <windowtitle>Books API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-books/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-books/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Books API ${project.version}</doctitle>
           <windowtitle>Books API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-books/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-books/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Books API ${project.version}</doctitle>
           <windowtitle>Books API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-calendar/v3/1.26.0/pom.xml
+++ b/clients/google-api-services-calendar/v3/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Calendar API ${project.version}</doctitle>
           <windowtitle>Calendar API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-calendar/v3/1.27.0/pom.xml
+++ b/clients/google-api-services-calendar/v3/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Calendar API ${project.version}</doctitle>
           <windowtitle>Calendar API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-calendar/v3/1.28.0/pom.xml
+++ b/clients/google-api-services-calendar/v3/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Calendar API ${project.version}</doctitle>
           <windowtitle>Calendar API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-chat/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-chat/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Hangouts Chat API ${project.version}</doctitle>
           <windowtitle>Hangouts Chat API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-chat/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-chat/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Hangouts Chat API ${project.version}</doctitle>
           <windowtitle>Hangouts Chat API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-chat/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-chat/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Hangouts Chat API ${project.version}</doctitle>
           <windowtitle>Hangouts Chat API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-civicinfo/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-civicinfo/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Civic Information API ${project.version}</doctitle>
           <windowtitle>Google Civic Information API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-civicinfo/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-civicinfo/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Civic Information API ${project.version}</doctitle>
           <windowtitle>Google Civic Information API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-civicinfo/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-civicinfo/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Civic Information API ${project.version}</doctitle>
           <windowtitle>Google Civic Information API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-classroom/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-classroom/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Classroom API ${project.version}</doctitle>
           <windowtitle>Google Classroom API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-classroom/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-classroom/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Classroom API ${project.version}</doctitle>
           <windowtitle>Google Classroom API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-classroom/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-classroom/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Classroom API ${project.version}</doctitle>
           <windowtitle>Google Classroom API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudbilling/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudbilling/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Billing API ${project.version}</doctitle>
           <windowtitle>Cloud Billing API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudbilling/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudbilling/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Billing API ${project.version}</doctitle>
           <windowtitle>Cloud Billing API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudbilling/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudbilling/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Billing API ${project.version}</doctitle>
           <windowtitle>Cloud Billing API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudbuild/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudbuild/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Build API ${project.version}</doctitle>
           <windowtitle>Cloud Build API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudbuild/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudbuild/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Build API ${project.version}</doctitle>
           <windowtitle>Cloud Build API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudbuild/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudbuild/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Build API ${project.version}</doctitle>
           <windowtitle>Cloud Build API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudbuild/v1alpha1/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudbuild/v1alpha1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Build API ${project.version}</doctitle>
           <windowtitle>Cloud Build API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudbuild/v1alpha1/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudbuild/v1alpha1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Build API ${project.version}</doctitle>
           <windowtitle>Cloud Build API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudbuild/v1alpha1/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudbuild/v1alpha1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Build API ${project.version}</doctitle>
           <windowtitle>Cloud Build API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-clouddebugger/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-clouddebugger/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Debugger API ${project.version}</doctitle>
           <windowtitle>Stackdriver Debugger API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-clouddebugger/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-clouddebugger/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Debugger API ${project.version}</doctitle>
           <windowtitle>Stackdriver Debugger API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-clouddebugger/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-clouddebugger/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Debugger API ${project.version}</doctitle>
           <windowtitle>Stackdriver Debugger API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-clouderrorreporting/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-clouderrorreporting/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Error Reporting API ${project.version}</doctitle>
           <windowtitle>Stackdriver Error Reporting API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-clouderrorreporting/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-clouderrorreporting/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Error Reporting API ${project.version}</doctitle>
           <windowtitle>Stackdriver Error Reporting API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-clouderrorreporting/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-clouderrorreporting/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Error Reporting API ${project.version}</doctitle>
           <windowtitle>Stackdriver Error Reporting API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudidentity/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudidentity/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Identity API ${project.version}</doctitle>
           <windowtitle>Cloud Identity API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudidentity/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudidentity/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Identity API ${project.version}</doctitle>
           <windowtitle>Cloud Identity API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudidentity/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudidentity/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Identity API ${project.version}</doctitle>
           <windowtitle>Cloud Identity API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudidentity/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudidentity/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Identity API ${project.version}</doctitle>
           <windowtitle>Cloud Identity API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudidentity/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudidentity/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Identity API ${project.version}</doctitle>
           <windowtitle>Cloud Identity API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudidentity/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudidentity/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Identity API ${project.version}</doctitle>
           <windowtitle>Cloud Identity API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudkms/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudkms/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Key Management Service (KMS) API ${project.version}</doctitle>
           <windowtitle>Cloud Key Management Service (KMS) API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudkms/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudkms/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Key Management Service (KMS) API ${project.version}</doctitle>
           <windowtitle>Cloud Key Management Service (KMS) API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudkms/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudkms/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Key Management Service (KMS) API ${project.version}</doctitle>
           <windowtitle>Cloud Key Management Service (KMS) API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudprivatecatalog/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudprivatecatalog/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Private Catalog API ${project.version}</doctitle>
           <windowtitle>Cloud Private Catalog API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudprivatecatalog/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudprivatecatalog/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Private Catalog API ${project.version}</doctitle>
           <windowtitle>Cloud Private Catalog API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudprivatecatalog/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudprivatecatalog/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Private Catalog API ${project.version}</doctitle>
           <windowtitle>Cloud Private Catalog API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudprivatecatalogproducer/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudprivatecatalogproducer/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Private Catalog Producer API ${project.version}</doctitle>
           <windowtitle>Cloud Private Catalog Producer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudprivatecatalogproducer/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudprivatecatalogproducer/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Private Catalog Producer API ${project.version}</doctitle>
           <windowtitle>Cloud Private Catalog Producer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudprivatecatalogproducer/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudprivatecatalogproducer/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Private Catalog Producer API ${project.version}</doctitle>
           <windowtitle>Cloud Private Catalog Producer API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudprofiler/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudprofiler/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Profiler API ${project.version}</doctitle>
           <windowtitle>Stackdriver Profiler API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudprofiler/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudprofiler/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Profiler API ${project.version}</doctitle>
           <windowtitle>Stackdriver Profiler API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudprofiler/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudprofiler/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Profiler API ${project.version}</doctitle>
           <windowtitle>Stackdriver Profiler API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudresourcemanager/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudresourcemanager/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Resource Manager API ${project.version}</doctitle>
           <windowtitle>Cloud Resource Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudresourcemanager/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudresourcemanager/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Resource Manager API ${project.version}</doctitle>
           <windowtitle>Cloud Resource Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudresourcemanager/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudresourcemanager/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Resource Manager API ${project.version}</doctitle>
           <windowtitle>Cloud Resource Manager API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudresourcemanager/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudresourcemanager/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Resource Manager API ${project.version}</doctitle>
           <windowtitle>Cloud Resource Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudresourcemanager/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudresourcemanager/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Resource Manager API ${project.version}</doctitle>
           <windowtitle>Cloud Resource Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudresourcemanager/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudresourcemanager/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Resource Manager API ${project.version}</doctitle>
           <windowtitle>Cloud Resource Manager API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudresourcemanager/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudresourcemanager/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Resource Manager API ${project.version}</doctitle>
           <windowtitle>Cloud Resource Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudresourcemanager/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudresourcemanager/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Resource Manager API ${project.version}</doctitle>
           <windowtitle>Cloud Resource Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudresourcemanager/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudresourcemanager/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Resource Manager API ${project.version}</doctitle>
           <windowtitle>Cloud Resource Manager API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudresourcemanager/v2beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudresourcemanager/v2beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Resource Manager API ${project.version}</doctitle>
           <windowtitle>Cloud Resource Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudresourcemanager/v2beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudresourcemanager/v2beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Resource Manager API ${project.version}</doctitle>
           <windowtitle>Cloud Resource Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudresourcemanager/v2beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudresourcemanager/v2beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Resource Manager API ${project.version}</doctitle>
           <windowtitle>Cloud Resource Manager API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudsearch/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudsearch/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Search API ${project.version}</doctitle>
           <windowtitle>Cloud Search API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudsearch/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudsearch/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Search API ${project.version}</doctitle>
           <windowtitle>Cloud Search API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudsearch/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudsearch/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Search API ${project.version}</doctitle>
           <windowtitle>Cloud Search API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudshell/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudshell/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Shell API ${project.version}</doctitle>
           <windowtitle>Cloud Shell API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudshell/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudshell/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Shell API ${project.version}</doctitle>
           <windowtitle>Cloud Shell API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudshell/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudshell/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Shell API ${project.version}</doctitle>
           <windowtitle>Cloud Shell API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudshell/v1alpha1/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudshell/v1alpha1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Shell API ${project.version}</doctitle>
           <windowtitle>Cloud Shell API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudshell/v1alpha1/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudshell/v1alpha1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Shell API ${project.version}</doctitle>
           <windowtitle>Cloud Shell API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudshell/v1alpha1/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudshell/v1alpha1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Shell API ${project.version}</doctitle>
           <windowtitle>Cloud Shell API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudtasks/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudtasks/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Tasks API ${project.version}</doctitle>
           <windowtitle>Cloud Tasks API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudtasks/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudtasks/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Tasks API ${project.version}</doctitle>
           <windowtitle>Cloud Tasks API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudtasks/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudtasks/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Tasks API ${project.version}</doctitle>
           <windowtitle>Cloud Tasks API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudtasks/v2beta2/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudtasks/v2beta2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Tasks API ${project.version}</doctitle>
           <windowtitle>Cloud Tasks API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudtasks/v2beta2/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudtasks/v2beta2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Tasks API ${project.version}</doctitle>
           <windowtitle>Cloud Tasks API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudtasks/v2beta2/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudtasks/v2beta2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Tasks API ${project.version}</doctitle>
           <windowtitle>Cloud Tasks API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudtasks/v2beta3/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudtasks/v2beta3/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Tasks API ${project.version}</doctitle>
           <windowtitle>Cloud Tasks API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudtasks/v2beta3/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudtasks/v2beta3/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Tasks API ${project.version}</doctitle>
           <windowtitle>Cloud Tasks API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudtasks/v2beta3/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudtasks/v2beta3/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Tasks API ${project.version}</doctitle>
           <windowtitle>Cloud Tasks API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudtrace/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudtrace/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Trace API ${project.version}</doctitle>
           <windowtitle>Stackdriver Trace API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudtrace/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudtrace/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Trace API ${project.version}</doctitle>
           <windowtitle>Stackdriver Trace API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudtrace/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudtrace/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Trace API ${project.version}</doctitle>
           <windowtitle>Stackdriver Trace API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudtrace/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-cloudtrace/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Trace API ${project.version}</doctitle>
           <windowtitle>Stackdriver Trace API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudtrace/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-cloudtrace/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Trace API ${project.version}</doctitle>
           <windowtitle>Stackdriver Trace API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-cloudtrace/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-cloudtrace/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Trace API ${project.version}</doctitle>
           <windowtitle>Stackdriver Trace API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-commentanalyzer/v1alpha1/1.26.0/pom.xml
+++ b/clients/google-api-services-commentanalyzer/v1alpha1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Perspective Comment Analyzer API ${project.version}</doctitle>
           <windowtitle>Perspective Comment Analyzer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-commentanalyzer/v1alpha1/1.27.0/pom.xml
+++ b/clients/google-api-services-commentanalyzer/v1alpha1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Perspective Comment Analyzer API ${project.version}</doctitle>
           <windowtitle>Perspective Comment Analyzer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-commentanalyzer/v1alpha1/1.28.0/pom.xml
+++ b/clients/google-api-services-commentanalyzer/v1alpha1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Perspective Comment Analyzer API ${project.version}</doctitle>
           <windowtitle>Perspective Comment Analyzer API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-composer/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-composer/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Composer API ${project.version}</doctitle>
           <windowtitle>Cloud Composer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-composer/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-composer/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Composer API ${project.version}</doctitle>
           <windowtitle>Cloud Composer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-composer/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-composer/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Composer API ${project.version}</doctitle>
           <windowtitle>Cloud Composer API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-composer/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-composer/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Composer API ${project.version}</doctitle>
           <windowtitle>Cloud Composer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-composer/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-composer/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Composer API ${project.version}</doctitle>
           <windowtitle>Cloud Composer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-composer/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-composer/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Composer API ${project.version}</doctitle>
           <windowtitle>Cloud Composer API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-container/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-container/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Kubernetes Engine API ${project.version}</doctitle>
           <windowtitle>Kubernetes Engine API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-container/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-container/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Kubernetes Engine API ${project.version}</doctitle>
           <windowtitle>Kubernetes Engine API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-container/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-container/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Kubernetes Engine API ${project.version}</doctitle>
           <windowtitle>Kubernetes Engine API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-container/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-container/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Kubernetes Engine API ${project.version}</doctitle>
           <windowtitle>Kubernetes Engine API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-container/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-container/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Kubernetes Engine API ${project.version}</doctitle>
           <windowtitle>Kubernetes Engine API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-container/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-container/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Kubernetes Engine API ${project.version}</doctitle>
           <windowtitle>Kubernetes Engine API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-containeranalysis/v1alpha1/1.26.0/pom.xml
+++ b/clients/google-api-services-containeranalysis/v1alpha1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Container Analysis API ${project.version}</doctitle>
           <windowtitle>Container Analysis API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-containeranalysis/v1alpha1/1.27.0/pom.xml
+++ b/clients/google-api-services-containeranalysis/v1alpha1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Container Analysis API ${project.version}</doctitle>
           <windowtitle>Container Analysis API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-containeranalysis/v1alpha1/1.28.0/pom.xml
+++ b/clients/google-api-services-containeranalysis/v1alpha1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Container Analysis API ${project.version}</doctitle>
           <windowtitle>Container Analysis API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-containeranalysis/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-containeranalysis/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Container Analysis API ${project.version}</doctitle>
           <windowtitle>Container Analysis API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-containeranalysis/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-containeranalysis/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Container Analysis API ${project.version}</doctitle>
           <windowtitle>Container Analysis API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-containeranalysis/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-containeranalysis/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Container Analysis API ${project.version}</doctitle>
           <windowtitle>Container Analysis API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-content/v2.1/1.26.0/pom.xml
+++ b/clients/google-api-services-content/v2.1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Content API for Shopping ${project.version}</doctitle>
           <windowtitle>Content API for Shopping ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-content/v2.1/1.27.0/pom.xml
+++ b/clients/google-api-services-content/v2.1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Content API for Shopping ${project.version}</doctitle>
           <windowtitle>Content API for Shopping ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-content/v2.1/1.28.0/pom.xml
+++ b/clients/google-api-services-content/v2.1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Content API for Shopping ${project.version}</doctitle>
           <windowtitle>Content API for Shopping ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-content/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-content/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Content API for Shopping ${project.version}</doctitle>
           <windowtitle>Content API for Shopping ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-content/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-content/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Content API for Shopping ${project.version}</doctitle>
           <windowtitle>Content API for Shopping ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-content/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-content/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Content API for Shopping ${project.version}</doctitle>
           <windowtitle>Content API for Shopping ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-customsearch/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-customsearch/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>CustomSearch API ${project.version}</doctitle>
           <windowtitle>CustomSearch API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-customsearch/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-customsearch/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>CustomSearch API ${project.version}</doctitle>
           <windowtitle>CustomSearch API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-customsearch/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-customsearch/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>CustomSearch API ${project.version}</doctitle>
           <windowtitle>CustomSearch API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dataflow/v1b3/1.26.0/pom.xml
+++ b/clients/google-api-services-dataflow/v1b3/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Dataflow API ${project.version}</doctitle>
           <windowtitle>Dataflow API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dataflow/v1b3/1.27.0/pom.xml
+++ b/clients/google-api-services-dataflow/v1b3/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Dataflow API ${project.version}</doctitle>
           <windowtitle>Dataflow API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dataflow/v1b3/1.28.0/pom.xml
+++ b/clients/google-api-services-dataflow/v1b3/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Dataflow API ${project.version}</doctitle>
           <windowtitle>Dataflow API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-datastore/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-datastore/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Datastore API ${project.version}</doctitle>
           <windowtitle>Cloud Datastore API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-datastore/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-datastore/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Datastore API ${project.version}</doctitle>
           <windowtitle>Cloud Datastore API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-datastore/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-datastore/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Datastore API ${project.version}</doctitle>
           <windowtitle>Cloud Datastore API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-datastore/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-datastore/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Datastore API ${project.version}</doctitle>
           <windowtitle>Cloud Datastore API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-datastore/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-datastore/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Datastore API ${project.version}</doctitle>
           <windowtitle>Cloud Datastore API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-datastore/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-datastore/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Datastore API ${project.version}</doctitle>
           <windowtitle>Cloud Datastore API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-datastore/v1beta3/1.26.0/pom.xml
+++ b/clients/google-api-services-datastore/v1beta3/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Datastore API ${project.version}</doctitle>
           <windowtitle>Cloud Datastore API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-datastore/v1beta3/1.27.0/pom.xml
+++ b/clients/google-api-services-datastore/v1beta3/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Datastore API ${project.version}</doctitle>
           <windowtitle>Cloud Datastore API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-datastore/v1beta3/1.28.0/pom.xml
+++ b/clients/google-api-services-datastore/v1beta3/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Datastore API ${project.version}</doctitle>
           <windowtitle>Cloud Datastore API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-deploymentmanager/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-deploymentmanager/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud Deployment Manager API ${project.version}</doctitle>
           <windowtitle>Google Cloud Deployment Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-deploymentmanager/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-deploymentmanager/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud Deployment Manager API ${project.version}</doctitle>
           <windowtitle>Google Cloud Deployment Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-deploymentmanager/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-deploymentmanager/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud Deployment Manager API ${project.version}</doctitle>
           <windowtitle>Google Cloud Deployment Manager API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-deploymentmanager/v2beta/1.26.0/pom.xml
+++ b/clients/google-api-services-deploymentmanager/v2beta/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud Deployment Manager API V2Beta Methods ${project.version}</doctitle>
           <windowtitle>Google Cloud Deployment Manager API V2Beta Methods ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-deploymentmanager/v2beta/1.27.0/pom.xml
+++ b/clients/google-api-services-deploymentmanager/v2beta/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud Deployment Manager API V2Beta Methods ${project.version}</doctitle>
           <windowtitle>Google Cloud Deployment Manager API V2Beta Methods ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-deploymentmanager/v2beta/1.28.0/pom.xml
+++ b/clients/google-api-services-deploymentmanager/v2beta/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud Deployment Manager API V2Beta Methods ${project.version}</doctitle>
           <windowtitle>Google Cloud Deployment Manager API V2Beta Methods ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dfareporting/v3.1/1.26.0/pom.xml
+++ b/clients/google-api-services-dfareporting/v3.1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>DCM/DFA Reporting And Trafficking API ${project.version}</doctitle>
           <windowtitle>DCM/DFA Reporting And Trafficking API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dfareporting/v3.1/1.27.0/pom.xml
+++ b/clients/google-api-services-dfareporting/v3.1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>DCM/DFA Reporting And Trafficking API ${project.version}</doctitle>
           <windowtitle>DCM/DFA Reporting And Trafficking API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dfareporting/v3.1/1.28.0/pom.xml
+++ b/clients/google-api-services-dfareporting/v3.1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>DCM/DFA Reporting And Trafficking API ${project.version}</doctitle>
           <windowtitle>DCM/DFA Reporting And Trafficking API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dfareporting/v3.2/1.26.0/pom.xml
+++ b/clients/google-api-services-dfareporting/v3.2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>DCM/DFA Reporting And Trafficking API ${project.version}</doctitle>
           <windowtitle>DCM/DFA Reporting And Trafficking API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dfareporting/v3.2/1.27.0/pom.xml
+++ b/clients/google-api-services-dfareporting/v3.2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>DCM/DFA Reporting And Trafficking API ${project.version}</doctitle>
           <windowtitle>DCM/DFA Reporting And Trafficking API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dfareporting/v3.2/1.28.0/pom.xml
+++ b/clients/google-api-services-dfareporting/v3.2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>DCM/DFA Reporting And Trafficking API ${project.version}</doctitle>
           <windowtitle>DCM/DFA Reporting And Trafficking API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dfareporting/v3.3/1.26.0/pom.xml
+++ b/clients/google-api-services-dfareporting/v3.3/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>DCM/DFA Reporting And Trafficking API ${project.version}</doctitle>
           <windowtitle>DCM/DFA Reporting And Trafficking API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dfareporting/v3.3/1.27.0/pom.xml
+++ b/clients/google-api-services-dfareporting/v3.3/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>DCM/DFA Reporting And Trafficking API ${project.version}</doctitle>
           <windowtitle>DCM/DFA Reporting And Trafficking API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dfareporting/v3.3/1.28.0/pom.xml
+++ b/clients/google-api-services-dfareporting/v3.3/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>DCM/DFA Reporting And Trafficking API ${project.version}</doctitle>
           <windowtitle>DCM/DFA Reporting And Trafficking API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-digitalassetlinks/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-digitalassetlinks/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Digital Asset Links API ${project.version}</doctitle>
           <windowtitle>Digital Asset Links API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-digitalassetlinks/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-digitalassetlinks/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Digital Asset Links API ${project.version}</doctitle>
           <windowtitle>Digital Asset Links API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-digitalassetlinks/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-digitalassetlinks/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Digital Asset Links API ${project.version}</doctitle>
           <windowtitle>Digital Asset Links API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-discovery/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-discovery/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>API Discovery Service ${project.version}</doctitle>
           <windowtitle>API Discovery Service ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-discovery/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-discovery/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>API Discovery Service ${project.version}</doctitle>
           <windowtitle>API Discovery Service ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-discovery/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-discovery/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>API Discovery Service ${project.version}</doctitle>
           <windowtitle>API Discovery Service ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dns/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-dns/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud DNS API ${project.version}</doctitle>
           <windowtitle>Google Cloud DNS API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dns/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-dns/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud DNS API ${project.version}</doctitle>
           <windowtitle>Google Cloud DNS API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dns/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-dns/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud DNS API ${project.version}</doctitle>
           <windowtitle>Google Cloud DNS API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dns/v1beta2/1.26.0/pom.xml
+++ b/clients/google-api-services-dns/v1beta2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud DNS API ${project.version}</doctitle>
           <windowtitle>Google Cloud DNS API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dns/v1beta2/1.27.0/pom.xml
+++ b/clients/google-api-services-dns/v1beta2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud DNS API ${project.version}</doctitle>
           <windowtitle>Google Cloud DNS API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dns/v1beta2/1.28.0/pom.xml
+++ b/clients/google-api-services-dns/v1beta2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud DNS API ${project.version}</doctitle>
           <windowtitle>Google Cloud DNS API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dns/v2beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-dns/v2beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud DNS API ${project.version}</doctitle>
           <windowtitle>Google Cloud DNS API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dns/v2beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-dns/v2beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud DNS API ${project.version}</doctitle>
           <windowtitle>Google Cloud DNS API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-dns/v2beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-dns/v2beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud DNS API ${project.version}</doctitle>
           <windowtitle>Google Cloud DNS API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-docs/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-docs/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Docs API ${project.version}</doctitle>
           <windowtitle>Google Docs API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-docs/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-docs/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Docs API ${project.version}</doctitle>
           <windowtitle>Google Docs API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-docs/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-docs/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Docs API ${project.version}</doctitle>
           <windowtitle>Google Docs API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-doubleclickbidmanager/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-doubleclickbidmanager/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>DoubleClick Bid Manager API ${project.version}</doctitle>
           <windowtitle>DoubleClick Bid Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-doubleclickbidmanager/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-doubleclickbidmanager/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>DoubleClick Bid Manager API ${project.version}</doctitle>
           <windowtitle>DoubleClick Bid Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-doubleclickbidmanager/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-doubleclickbidmanager/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>DoubleClick Bid Manager API ${project.version}</doctitle>
           <windowtitle>DoubleClick Bid Manager API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-doubleclicksearch/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-doubleclicksearch/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>DoubleClick Search API ${project.version}</doctitle>
           <windowtitle>DoubleClick Search API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-doubleclicksearch/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-doubleclicksearch/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>DoubleClick Search API ${project.version}</doctitle>
           <windowtitle>DoubleClick Search API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-doubleclicksearch/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-doubleclicksearch/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>DoubleClick Search API ${project.version}</doctitle>
           <windowtitle>DoubleClick Search API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-drive/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-drive/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Drive API ${project.version}</doctitle>
           <windowtitle>Drive API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-drive/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-drive/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Drive API ${project.version}</doctitle>
           <windowtitle>Drive API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-drive/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-drive/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Drive API ${project.version}</doctitle>
           <windowtitle>Drive API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-drive/v3/1.26.0/pom.xml
+++ b/clients/google-api-services-drive/v3/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Drive API ${project.version}</doctitle>
           <windowtitle>Drive API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-drive/v3/1.27.0/pom.xml
+++ b/clients/google-api-services-drive/v3/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Drive API ${project.version}</doctitle>
           <windowtitle>Drive API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-drive/v3/1.28.0/pom.xml
+++ b/clients/google-api-services-drive/v3/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Drive API ${project.version}</doctitle>
           <windowtitle>Drive API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-driveactivity/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-driveactivity/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Drive Activity API ${project.version}</doctitle>
           <windowtitle>Drive Activity API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-driveactivity/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-driveactivity/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Drive Activity API ${project.version}</doctitle>
           <windowtitle>Drive Activity API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-driveactivity/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-driveactivity/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Drive Activity API ${project.version}</doctitle>
           <windowtitle>Drive Activity API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-factchecktools/v1alpha1/1.26.0/pom.xml
+++ b/clients/google-api-services-factchecktools/v1alpha1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Fact Check Tools API ${project.version}</doctitle>
           <windowtitle>Fact Check Tools API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-factchecktools/v1alpha1/1.27.0/pom.xml
+++ b/clients/google-api-services-factchecktools/v1alpha1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Fact Check Tools API ${project.version}</doctitle>
           <windowtitle>Fact Check Tools API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-factchecktools/v1alpha1/1.28.0/pom.xml
+++ b/clients/google-api-services-factchecktools/v1alpha1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Fact Check Tools API ${project.version}</doctitle>
           <windowtitle>Fact Check Tools API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-fcm/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-fcm/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Firebase Cloud Messaging API ${project.version}</doctitle>
           <windowtitle>Firebase Cloud Messaging API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-fcm/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-fcm/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Firebase Cloud Messaging API ${project.version}</doctitle>
           <windowtitle>Firebase Cloud Messaging API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-fcm/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-fcm/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Firebase Cloud Messaging API ${project.version}</doctitle>
           <windowtitle>Firebase Cloud Messaging API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-file/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-file/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Filestore API ${project.version}</doctitle>
           <windowtitle>Cloud Filestore API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-file/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-file/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Filestore API ${project.version}</doctitle>
           <windowtitle>Cloud Filestore API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-file/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-file/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Filestore API ${project.version}</doctitle>
           <windowtitle>Cloud Filestore API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-file/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-file/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Filestore API ${project.version}</doctitle>
           <windowtitle>Cloud Filestore API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-file/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-file/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Filestore API ${project.version}</doctitle>
           <windowtitle>Cloud Filestore API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-file/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-file/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Filestore API ${project.version}</doctitle>
           <windowtitle>Cloud Filestore API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firebasedynamiclinks/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-firebasedynamiclinks/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Firebase Dynamic Links API ${project.version}</doctitle>
           <windowtitle>Firebase Dynamic Links API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firebasedynamiclinks/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-firebasedynamiclinks/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Firebase Dynamic Links API ${project.version}</doctitle>
           <windowtitle>Firebase Dynamic Links API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firebasedynamiclinks/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-firebasedynamiclinks/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Firebase Dynamic Links API ${project.version}</doctitle>
           <windowtitle>Firebase Dynamic Links API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firebasehosting/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-firebasehosting/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Firebase Hosting API ${project.version}</doctitle>
           <windowtitle>Firebase Hosting API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firebasehosting/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-firebasehosting/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Firebase Hosting API ${project.version}</doctitle>
           <windowtitle>Firebase Hosting API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firebasehosting/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-firebasehosting/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Firebase Hosting API ${project.version}</doctitle>
           <windowtitle>Firebase Hosting API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firebaserules/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-firebaserules/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Firebase Rules API ${project.version}</doctitle>
           <windowtitle>Firebase Rules API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firebaserules/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-firebaserules/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Firebase Rules API ${project.version}</doctitle>
           <windowtitle>Firebase Rules API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firebaserules/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-firebaserules/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Firebase Rules API ${project.version}</doctitle>
           <windowtitle>Firebase Rules API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firestore/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-firestore/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Firestore API ${project.version}</doctitle>
           <windowtitle>Cloud Firestore API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firestore/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-firestore/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Firestore API ${project.version}</doctitle>
           <windowtitle>Cloud Firestore API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firestore/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-firestore/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Firestore API ${project.version}</doctitle>
           <windowtitle>Cloud Firestore API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firestore/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-firestore/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Firestore API ${project.version}</doctitle>
           <windowtitle>Cloud Firestore API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firestore/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-firestore/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Firestore API ${project.version}</doctitle>
           <windowtitle>Cloud Firestore API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firestore/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-firestore/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Firestore API ${project.version}</doctitle>
           <windowtitle>Cloud Firestore API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firestore/v1beta2/1.26.0/pom.xml
+++ b/clients/google-api-services-firestore/v1beta2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Firestore API ${project.version}</doctitle>
           <windowtitle>Cloud Firestore API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firestore/v1beta2/1.27.0/pom.xml
+++ b/clients/google-api-services-firestore/v1beta2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Firestore API ${project.version}</doctitle>
           <windowtitle>Cloud Firestore API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-firestore/v1beta2/1.28.0/pom.xml
+++ b/clients/google-api-services-firestore/v1beta2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Firestore API ${project.version}</doctitle>
           <windowtitle>Cloud Firestore API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-fitness/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-fitness/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Fitness ${project.version}</doctitle>
           <windowtitle>Fitness ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-fitness/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-fitness/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Fitness ${project.version}</doctitle>
           <windowtitle>Fitness ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-fitness/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-fitness/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Fitness ${project.version}</doctitle>
           <windowtitle>Fitness ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-fusiontables/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-fusiontables/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Fusion Tables API ${project.version}</doctitle>
           <windowtitle>Fusion Tables API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-fusiontables/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-fusiontables/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Fusion Tables API ${project.version}</doctitle>
           <windowtitle>Fusion Tables API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-fusiontables/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-fusiontables/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Fusion Tables API ${project.version}</doctitle>
           <windowtitle>Fusion Tables API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-fusiontables/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-fusiontables/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Fusion Tables API ${project.version}</doctitle>
           <windowtitle>Fusion Tables API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-fusiontables/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-fusiontables/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Fusion Tables API ${project.version}</doctitle>
           <windowtitle>Fusion Tables API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-fusiontables/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-fusiontables/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Fusion Tables API ${project.version}</doctitle>
           <windowtitle>Fusion Tables API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-games/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-games/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Game Services API ${project.version}</doctitle>
           <windowtitle>Google Play Game Services API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-games/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-games/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Game Services API ${project.version}</doctitle>
           <windowtitle>Google Play Game Services API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-games/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-games/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Game Services API ${project.version}</doctitle>
           <windowtitle>Google Play Game Services API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-gamesConfiguration/v1configuration/1.26.0/pom.xml
+++ b/clients/google-api-services-gamesConfiguration/v1configuration/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Game Services Publishing API ${project.version}</doctitle>
           <windowtitle>Google Play Game Services Publishing API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-gamesConfiguration/v1configuration/1.27.0/pom.xml
+++ b/clients/google-api-services-gamesConfiguration/v1configuration/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Game Services Publishing API ${project.version}</doctitle>
           <windowtitle>Google Play Game Services Publishing API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-gamesConfiguration/v1configuration/1.28.0/pom.xml
+++ b/clients/google-api-services-gamesConfiguration/v1configuration/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Game Services Publishing API ${project.version}</doctitle>
           <windowtitle>Google Play Game Services Publishing API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-gamesManagement/v1management/1.26.0/pom.xml
+++ b/clients/google-api-services-gamesManagement/v1management/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Game Services Management API ${project.version}</doctitle>
           <windowtitle>Google Play Game Services Management API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-gamesManagement/v1management/1.27.0/pom.xml
+++ b/clients/google-api-services-gamesManagement/v1management/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Game Services Management API ${project.version}</doctitle>
           <windowtitle>Google Play Game Services Management API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-gamesManagement/v1management/1.28.0/pom.xml
+++ b/clients/google-api-services-gamesManagement/v1management/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Game Services Management API ${project.version}</doctitle>
           <windowtitle>Google Play Game Services Management API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-genomics/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-genomics/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Genomics API ${project.version}</doctitle>
           <windowtitle>Genomics API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-genomics/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-genomics/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Genomics API ${project.version}</doctitle>
           <windowtitle>Genomics API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-genomics/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-genomics/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Genomics API ${project.version}</doctitle>
           <windowtitle>Genomics API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-genomics/v1alpha2/1.26.0/pom.xml
+++ b/clients/google-api-services-genomics/v1alpha2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Genomics API ${project.version}</doctitle>
           <windowtitle>Genomics API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-genomics/v1alpha2/1.27.0/pom.xml
+++ b/clients/google-api-services-genomics/v1alpha2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Genomics API ${project.version}</doctitle>
           <windowtitle>Genomics API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-genomics/v1alpha2/1.28.0/pom.xml
+++ b/clients/google-api-services-genomics/v1alpha2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Genomics API ${project.version}</doctitle>
           <windowtitle>Genomics API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-genomics/v2alpha1/1.26.0/pom.xml
+++ b/clients/google-api-services-genomics/v2alpha1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Genomics API ${project.version}</doctitle>
           <windowtitle>Genomics API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-genomics/v2alpha1/1.27.0/pom.xml
+++ b/clients/google-api-services-genomics/v2alpha1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Genomics API ${project.version}</doctitle>
           <windowtitle>Genomics API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-genomics/v2alpha1/1.28.0/pom.xml
+++ b/clients/google-api-services-genomics/v2alpha1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Genomics API ${project.version}</doctitle>
           <windowtitle>Genomics API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-gmail/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-gmail/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Gmail API ${project.version}</doctitle>
           <windowtitle>Gmail API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-gmail/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-gmail/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Gmail API ${project.version}</doctitle>
           <windowtitle>Gmail API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-gmail/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-gmail/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Gmail API ${project.version}</doctitle>
           <windowtitle>Gmail API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-groupsmigration/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-groupsmigration/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Groups Migration API ${project.version}</doctitle>
           <windowtitle>Groups Migration API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-groupsmigration/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-groupsmigration/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Groups Migration API ${project.version}</doctitle>
           <windowtitle>Groups Migration API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-groupsmigration/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-groupsmigration/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Groups Migration API ${project.version}</doctitle>
           <windowtitle>Groups Migration API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-groupssettings/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-groupssettings/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Groups Settings API ${project.version}</doctitle>
           <windowtitle>Groups Settings API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-groupssettings/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-groupssettings/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Groups Settings API ${project.version}</doctitle>
           <windowtitle>Groups Settings API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-groupssettings/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-groupssettings/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Groups Settings API ${project.version}</doctitle>
           <windowtitle>Groups Settings API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-healthcare/v1alpha2/1.26.0/pom.xml
+++ b/clients/google-api-services-healthcare/v1alpha2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Healthcare API ${project.version}</doctitle>
           <windowtitle>Cloud Healthcare API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-healthcare/v1alpha2/1.27.0/pom.xml
+++ b/clients/google-api-services-healthcare/v1alpha2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Healthcare API ${project.version}</doctitle>
           <windowtitle>Cloud Healthcare API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-healthcare/v1alpha2/1.28.0/pom.xml
+++ b/clients/google-api-services-healthcare/v1alpha2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Healthcare API ${project.version}</doctitle>
           <windowtitle>Cloud Healthcare API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-healthcare/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-healthcare/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Healthcare API ${project.version}</doctitle>
           <windowtitle>Cloud Healthcare API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-healthcare/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-healthcare/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Healthcare API ${project.version}</doctitle>
           <windowtitle>Cloud Healthcare API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-healthcare/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-healthcare/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Healthcare API ${project.version}</doctitle>
           <windowtitle>Cloud Healthcare API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-iamcredentials/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-iamcredentials/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>IAM Service Account Credentials API ${project.version}</doctitle>
           <windowtitle>IAM Service Account Credentials API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-iamcredentials/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-iamcredentials/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>IAM Service Account Credentials API ${project.version}</doctitle>
           <windowtitle>IAM Service Account Credentials API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-iamcredentials/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-iamcredentials/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>IAM Service Account Credentials API ${project.version}</doctitle>
           <windowtitle>IAM Service Account Credentials API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-iap/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-iap/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Identity-Aware Proxy API ${project.version}</doctitle>
           <windowtitle>Cloud Identity-Aware Proxy API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-iap/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-iap/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Identity-Aware Proxy API ${project.version}</doctitle>
           <windowtitle>Cloud Identity-Aware Proxy API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-iap/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-iap/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Identity-Aware Proxy API ${project.version}</doctitle>
           <windowtitle>Cloud Identity-Aware Proxy API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-iap/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-iap/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Identity-Aware Proxy API ${project.version}</doctitle>
           <windowtitle>Cloud Identity-Aware Proxy API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-iap/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-iap/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Identity-Aware Proxy API ${project.version}</doctitle>
           <windowtitle>Cloud Identity-Aware Proxy API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-iap/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-iap/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Identity-Aware Proxy API ${project.version}</doctitle>
           <windowtitle>Cloud Identity-Aware Proxy API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-identitytoolkit/v3/1.26.0/pom.xml
+++ b/clients/google-api-services-identitytoolkit/v3/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Identity Toolkit API ${project.version}</doctitle>
           <windowtitle>Google Identity Toolkit API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-identitytoolkit/v3/1.27.0/pom.xml
+++ b/clients/google-api-services-identitytoolkit/v3/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Identity Toolkit API ${project.version}</doctitle>
           <windowtitle>Google Identity Toolkit API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-identitytoolkit/v3/1.28.0/pom.xml
+++ b/clients/google-api-services-identitytoolkit/v3/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Identity Toolkit API ${project.version}</doctitle>
           <windowtitle>Google Identity Toolkit API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-indexing/v3/1.26.0/pom.xml
+++ b/clients/google-api-services-indexing/v3/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Indexing API ${project.version}</doctitle>
           <windowtitle>Indexing API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-indexing/v3/1.27.0/pom.xml
+++ b/clients/google-api-services-indexing/v3/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Indexing API ${project.version}</doctitle>
           <windowtitle>Indexing API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-indexing/v3/1.28.0/pom.xml
+++ b/clients/google-api-services-indexing/v3/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Indexing API ${project.version}</doctitle>
           <windowtitle>Indexing API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-jobs/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-jobs/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Talent Solution API ${project.version}</doctitle>
           <windowtitle>Cloud Talent Solution API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-jobs/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-jobs/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Talent Solution API ${project.version}</doctitle>
           <windowtitle>Cloud Talent Solution API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-jobs/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-jobs/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Talent Solution API ${project.version}</doctitle>
           <windowtitle>Cloud Talent Solution API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-jobs/v3/1.26.0/pom.xml
+++ b/clients/google-api-services-jobs/v3/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Talent Solution API ${project.version}</doctitle>
           <windowtitle>Cloud Talent Solution API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-jobs/v3/1.27.0/pom.xml
+++ b/clients/google-api-services-jobs/v3/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Talent Solution API ${project.version}</doctitle>
           <windowtitle>Cloud Talent Solution API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-jobs/v3/1.28.0/pom.xml
+++ b/clients/google-api-services-jobs/v3/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Talent Solution API ${project.version}</doctitle>
           <windowtitle>Cloud Talent Solution API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-jobs/v3p1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-jobs/v3p1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Talent Solution API ${project.version}</doctitle>
           <windowtitle>Cloud Talent Solution API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-jobs/v3p1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-jobs/v3p1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Talent Solution API ${project.version}</doctitle>
           <windowtitle>Cloud Talent Solution API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-jobs/v3p1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-jobs/v3p1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Talent Solution API ${project.version}</doctitle>
           <windowtitle>Cloud Talent Solution API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-kgsearch/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-kgsearch/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Knowledge Graph Search API ${project.version}</doctitle>
           <windowtitle>Knowledge Graph Search API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-kgsearch/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-kgsearch/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Knowledge Graph Search API ${project.version}</doctitle>
           <windowtitle>Knowledge Graph Search API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-kgsearch/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-kgsearch/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Knowledge Graph Search API ${project.version}</doctitle>
           <windowtitle>Knowledge Graph Search API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-language/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-language/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Natural Language API ${project.version}</doctitle>
           <windowtitle>Cloud Natural Language API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-language/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-language/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Natural Language API ${project.version}</doctitle>
           <windowtitle>Cloud Natural Language API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-language/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-language/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Natural Language API ${project.version}</doctitle>
           <windowtitle>Cloud Natural Language API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-language/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-language/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Natural Language API ${project.version}</doctitle>
           <windowtitle>Cloud Natural Language API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-language/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-language/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Natural Language API ${project.version}</doctitle>
           <windowtitle>Cloud Natural Language API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-language/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-language/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Natural Language API ${project.version}</doctitle>
           <windowtitle>Cloud Natural Language API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-language/v1beta2/1.26.0/pom.xml
+++ b/clients/google-api-services-language/v1beta2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Natural Language API ${project.version}</doctitle>
           <windowtitle>Cloud Natural Language API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-language/v1beta2/1.27.0/pom.xml
+++ b/clients/google-api-services-language/v1beta2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Natural Language API ${project.version}</doctitle>
           <windowtitle>Cloud Natural Language API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-language/v1beta2/1.28.0/pom.xml
+++ b/clients/google-api-services-language/v1beta2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Natural Language API ${project.version}</doctitle>
           <windowtitle>Cloud Natural Language API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-libraryagent/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-libraryagent/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Library Agent API ${project.version}</doctitle>
           <windowtitle>Library Agent API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-libraryagent/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-libraryagent/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Library Agent API ${project.version}</doctitle>
           <windowtitle>Library Agent API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-libraryagent/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-libraryagent/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Library Agent API ${project.version}</doctitle>
           <windowtitle>Library Agent API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-licensing/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-licensing/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Enterprise License Manager API ${project.version}</doctitle>
           <windowtitle>Enterprise License Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-licensing/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-licensing/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Enterprise License Manager API ${project.version}</doctitle>
           <windowtitle>Enterprise License Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-licensing/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-licensing/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Enterprise License Manager API ${project.version}</doctitle>
           <windowtitle>Enterprise License Manager API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-logging/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-logging/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Logging API ${project.version}</doctitle>
           <windowtitle>Stackdriver Logging API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-logging/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-logging/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Logging API ${project.version}</doctitle>
           <windowtitle>Stackdriver Logging API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-logging/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-logging/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Logging API ${project.version}</doctitle>
           <windowtitle>Stackdriver Logging API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-manufacturers/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-manufacturers/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Manufacturer Center API ${project.version}</doctitle>
           <windowtitle>Manufacturer Center API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-manufacturers/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-manufacturers/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Manufacturer Center API ${project.version}</doctitle>
           <windowtitle>Manufacturer Center API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-manufacturers/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-manufacturers/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Manufacturer Center API ${project.version}</doctitle>
           <windowtitle>Manufacturer Center API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-mirror/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-mirror/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Mirror API ${project.version}</doctitle>
           <windowtitle>Google Mirror API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-mirror/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-mirror/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Mirror API ${project.version}</doctitle>
           <windowtitle>Google Mirror API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-mirror/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-mirror/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Mirror API ${project.version}</doctitle>
           <windowtitle>Google Mirror API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-ml/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-ml/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Machine Learning Engine ${project.version}</doctitle>
           <windowtitle>Cloud Machine Learning Engine ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-ml/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-ml/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Machine Learning Engine ${project.version}</doctitle>
           <windowtitle>Cloud Machine Learning Engine ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-ml/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-ml/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Machine Learning Engine ${project.version}</doctitle>
           <windowtitle>Cloud Machine Learning Engine ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-monitoring/v3/1.26.0/pom.xml
+++ b/clients/google-api-services-monitoring/v3/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Monitoring API ${project.version}</doctitle>
           <windowtitle>Stackdriver Monitoring API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-monitoring/v3/1.27.0/pom.xml
+++ b/clients/google-api-services-monitoring/v3/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Monitoring API ${project.version}</doctitle>
           <windowtitle>Stackdriver Monitoring API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-monitoring/v3/1.28.0/pom.xml
+++ b/clients/google-api-services-monitoring/v3/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Stackdriver Monitoring API ${project.version}</doctitle>
           <windowtitle>Stackdriver Monitoring API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-oauth2/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-oauth2/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google OAuth2 API ${project.version}</doctitle>
           <windowtitle>Google OAuth2 API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-oauth2/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-oauth2/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google OAuth2 API ${project.version}</doctitle>
           <windowtitle>Google OAuth2 API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-oauth2/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-oauth2/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google OAuth2 API ${project.version}</doctitle>
           <windowtitle>Google OAuth2 API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-oauth2/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-oauth2/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google OAuth2 API ${project.version}</doctitle>
           <windowtitle>Google OAuth2 API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-oauth2/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-oauth2/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google OAuth2 API ${project.version}</doctitle>
           <windowtitle>Google OAuth2 API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-oauth2/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-oauth2/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google OAuth2 API ${project.version}</doctitle>
           <windowtitle>Google OAuth2 API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-oslogin/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-oslogin/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud OS Login API ${project.version}</doctitle>
           <windowtitle>Cloud OS Login API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-oslogin/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-oslogin/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud OS Login API ${project.version}</doctitle>
           <windowtitle>Cloud OS Login API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-oslogin/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-oslogin/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud OS Login API ${project.version}</doctitle>
           <windowtitle>Cloud OS Login API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-oslogin/v1alpha/1.26.0/pom.xml
+++ b/clients/google-api-services-oslogin/v1alpha/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud OS Login API ${project.version}</doctitle>
           <windowtitle>Cloud OS Login API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-oslogin/v1alpha/1.27.0/pom.xml
+++ b/clients/google-api-services-oslogin/v1alpha/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud OS Login API ${project.version}</doctitle>
           <windowtitle>Cloud OS Login API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-oslogin/v1alpha/1.28.0/pom.xml
+++ b/clients/google-api-services-oslogin/v1alpha/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud OS Login API ${project.version}</doctitle>
           <windowtitle>Cloud OS Login API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-oslogin/v1beta/1.26.0/pom.xml
+++ b/clients/google-api-services-oslogin/v1beta/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud OS Login API ${project.version}</doctitle>
           <windowtitle>Cloud OS Login API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-oslogin/v1beta/1.27.0/pom.xml
+++ b/clients/google-api-services-oslogin/v1beta/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud OS Login API ${project.version}</doctitle>
           <windowtitle>Cloud OS Login API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-oslogin/v1beta/1.28.0/pom.xml
+++ b/clients/google-api-services-oslogin/v1beta/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud OS Login API ${project.version}</doctitle>
           <windowtitle>Cloud OS Login API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pagespeedonline/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-pagespeedonline/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>PageSpeed Insights API ${project.version}</doctitle>
           <windowtitle>PageSpeed Insights API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pagespeedonline/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-pagespeedonline/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>PageSpeed Insights API ${project.version}</doctitle>
           <windowtitle>PageSpeed Insights API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pagespeedonline/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-pagespeedonline/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>PageSpeed Insights API ${project.version}</doctitle>
           <windowtitle>PageSpeed Insights API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pagespeedonline/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-pagespeedonline/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>PageSpeed Insights API ${project.version}</doctitle>
           <windowtitle>PageSpeed Insights API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pagespeedonline/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-pagespeedonline/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>PageSpeed Insights API ${project.version}</doctitle>
           <windowtitle>PageSpeed Insights API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pagespeedonline/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-pagespeedonline/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>PageSpeed Insights API ${project.version}</doctitle>
           <windowtitle>PageSpeed Insights API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pagespeedonline/v4/1.26.0/pom.xml
+++ b/clients/google-api-services-pagespeedonline/v4/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>PageSpeed Insights API ${project.version}</doctitle>
           <windowtitle>PageSpeed Insights API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pagespeedonline/v4/1.27.0/pom.xml
+++ b/clients/google-api-services-pagespeedonline/v4/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>PageSpeed Insights API ${project.version}</doctitle>
           <windowtitle>PageSpeed Insights API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pagespeedonline/v4/1.28.0/pom.xml
+++ b/clients/google-api-services-pagespeedonline/v4/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>PageSpeed Insights API ${project.version}</doctitle>
           <windowtitle>PageSpeed Insights API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pagespeedonline/v5/1.26.0/pom.xml
+++ b/clients/google-api-services-pagespeedonline/v5/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>PageSpeed Insights API ${project.version}</doctitle>
           <windowtitle>PageSpeed Insights API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pagespeedonline/v5/1.27.0/pom.xml
+++ b/clients/google-api-services-pagespeedonline/v5/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>PageSpeed Insights API ${project.version}</doctitle>
           <windowtitle>PageSpeed Insights API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pagespeedonline/v5/1.28.0/pom.xml
+++ b/clients/google-api-services-pagespeedonline/v5/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>PageSpeed Insights API ${project.version}</doctitle>
           <windowtitle>PageSpeed Insights API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-playcustomapp/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-playcustomapp/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Custom App Publishing API ${project.version}</doctitle>
           <windowtitle>Google Play Custom App Publishing API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-playcustomapp/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-playcustomapp/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Custom App Publishing API ${project.version}</doctitle>
           <windowtitle>Google Play Custom App Publishing API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-playcustomapp/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-playcustomapp/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Play Custom App Publishing API ${project.version}</doctitle>
           <windowtitle>Google Play Custom App Publishing API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-plus/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-plus/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google+ API ${project.version}</doctitle>
           <windowtitle>Google+ API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-plus/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-plus/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google+ API ${project.version}</doctitle>
           <windowtitle>Google+ API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-plus/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-plus/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google+ API ${project.version}</doctitle>
           <windowtitle>Google+ API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-plusDomains/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-plusDomains/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google+ Domains API ${project.version}</doctitle>
           <windowtitle>Google+ Domains API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-plusDomains/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-plusDomains/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google+ Domains API ${project.version}</doctitle>
           <windowtitle>Google+ Domains API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-plusDomains/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-plusDomains/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google+ Domains API ${project.version}</doctitle>
           <windowtitle>Google+ Domains API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-poly/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-poly/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Poly API ${project.version}</doctitle>
           <windowtitle>Poly API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-poly/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-poly/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Poly API ${project.version}</doctitle>
           <windowtitle>Poly API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-poly/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-poly/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Poly API ${project.version}</doctitle>
           <windowtitle>Poly API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-proximitybeacon/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-proximitybeacon/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Proximity Beacon API ${project.version}</doctitle>
           <windowtitle>Proximity Beacon API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-proximitybeacon/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-proximitybeacon/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Proximity Beacon API ${project.version}</doctitle>
           <windowtitle>Proximity Beacon API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-proximitybeacon/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-proximitybeacon/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Proximity Beacon API ${project.version}</doctitle>
           <windowtitle>Proximity Beacon API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pubsub/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-pubsub/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Pub/Sub API ${project.version}</doctitle>
           <windowtitle>Cloud Pub/Sub API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pubsub/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-pubsub/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Pub/Sub API ${project.version}</doctitle>
           <windowtitle>Cloud Pub/Sub API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pubsub/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-pubsub/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Pub/Sub API ${project.version}</doctitle>
           <windowtitle>Cloud Pub/Sub API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pubsub/v1beta1a/1.26.0/pom.xml
+++ b/clients/google-api-services-pubsub/v1beta1a/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Pub/Sub API ${project.version}</doctitle>
           <windowtitle>Cloud Pub/Sub API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pubsub/v1beta1a/1.27.0/pom.xml
+++ b/clients/google-api-services-pubsub/v1beta1a/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Pub/Sub API ${project.version}</doctitle>
           <windowtitle>Cloud Pub/Sub API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pubsub/v1beta1a/1.28.0/pom.xml
+++ b/clients/google-api-services-pubsub/v1beta1a/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Pub/Sub API ${project.version}</doctitle>
           <windowtitle>Cloud Pub/Sub API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pubsub/v1beta2/1.26.0/pom.xml
+++ b/clients/google-api-services-pubsub/v1beta2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Pub/Sub API ${project.version}</doctitle>
           <windowtitle>Cloud Pub/Sub API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pubsub/v1beta2/1.27.0/pom.xml
+++ b/clients/google-api-services-pubsub/v1beta2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Pub/Sub API ${project.version}</doctitle>
           <windowtitle>Cloud Pub/Sub API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-pubsub/v1beta2/1.28.0/pom.xml
+++ b/clients/google-api-services-pubsub/v1beta2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Pub/Sub API ${project.version}</doctitle>
           <windowtitle>Cloud Pub/Sub API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-redis/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-redis/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud Memorystore for Redis API ${project.version}</doctitle>
           <windowtitle>Google Cloud Memorystore for Redis API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-redis/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-redis/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud Memorystore for Redis API ${project.version}</doctitle>
           <windowtitle>Google Cloud Memorystore for Redis API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-redis/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-redis/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud Memorystore for Redis API ${project.version}</doctitle>
           <windowtitle>Google Cloud Memorystore for Redis API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-redis/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-redis/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud Memorystore for Redis API ${project.version}</doctitle>
           <windowtitle>Google Cloud Memorystore for Redis API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-redis/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-redis/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud Memorystore for Redis API ${project.version}</doctitle>
           <windowtitle>Google Cloud Memorystore for Redis API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-redis/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-redis/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud Memorystore for Redis API ${project.version}</doctitle>
           <windowtitle>Google Cloud Memorystore for Redis API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-remotebuildexecution/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-remotebuildexecution/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Remote Build Execution API ${project.version}</doctitle>
           <windowtitle>Remote Build Execution API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-remotebuildexecution/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-remotebuildexecution/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Remote Build Execution API ${project.version}</doctitle>
           <windowtitle>Remote Build Execution API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-remotebuildexecution/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-remotebuildexecution/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Remote Build Execution API ${project.version}</doctitle>
           <windowtitle>Remote Build Execution API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-remotebuildexecution/v1alpha/1.26.0/pom.xml
+++ b/clients/google-api-services-remotebuildexecution/v1alpha/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Remote Build Execution API ${project.version}</doctitle>
           <windowtitle>Remote Build Execution API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-remotebuildexecution/v1alpha/1.27.0/pom.xml
+++ b/clients/google-api-services-remotebuildexecution/v1alpha/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Remote Build Execution API ${project.version}</doctitle>
           <windowtitle>Remote Build Execution API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-remotebuildexecution/v1alpha/1.28.0/pom.xml
+++ b/clients/google-api-services-remotebuildexecution/v1alpha/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Remote Build Execution API ${project.version}</doctitle>
           <windowtitle>Remote Build Execution API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-remotebuildexecution/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-remotebuildexecution/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Remote Build Execution API ${project.version}</doctitle>
           <windowtitle>Remote Build Execution API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-remotebuildexecution/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-remotebuildexecution/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Remote Build Execution API ${project.version}</doctitle>
           <windowtitle>Remote Build Execution API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-remotebuildexecution/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-remotebuildexecution/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Remote Build Execution API ${project.version}</doctitle>
           <windowtitle>Remote Build Execution API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-replicapool/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-replicapool/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Replica Pool API ${project.version}</doctitle>
           <windowtitle>Replica Pool API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-replicapool/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-replicapool/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Replica Pool API ${project.version}</doctitle>
           <windowtitle>Replica Pool API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-replicapool/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-replicapool/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Replica Pool API ${project.version}</doctitle>
           <windowtitle>Replica Pool API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-reseller/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-reseller/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Enterprise Apps Reseller API ${project.version}</doctitle>
           <windowtitle>Enterprise Apps Reseller API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-reseller/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-reseller/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Enterprise Apps Reseller API ${project.version}</doctitle>
           <windowtitle>Enterprise Apps Reseller API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-reseller/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-reseller/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Enterprise Apps Reseller API ${project.version}</doctitle>
           <windowtitle>Enterprise Apps Reseller API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-run/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-run/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Run API ${project.version}</doctitle>
           <windowtitle>Cloud Run API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-run/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-run/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Run API ${project.version}</doctitle>
           <windowtitle>Cloud Run API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-run/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-run/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Run API ${project.version}</doctitle>
           <windowtitle>Cloud Run API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-run/v1alpha1/1.26.0/pom.xml
+++ b/clients/google-api-services-run/v1alpha1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Run API ${project.version}</doctitle>
           <windowtitle>Cloud Run API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-run/v1alpha1/1.27.0/pom.xml
+++ b/clients/google-api-services-run/v1alpha1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Run API ${project.version}</doctitle>
           <windowtitle>Cloud Run API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-run/v1alpha1/1.28.0/pom.xml
+++ b/clients/google-api-services-run/v1alpha1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Run API ${project.version}</doctitle>
           <windowtitle>Cloud Run API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-runtimeconfig/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-runtimeconfig/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Runtime Configuration API ${project.version}</doctitle>
           <windowtitle>Cloud Runtime Configuration API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-runtimeconfig/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-runtimeconfig/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Runtime Configuration API ${project.version}</doctitle>
           <windowtitle>Cloud Runtime Configuration API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-runtimeconfig/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-runtimeconfig/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Runtime Configuration API ${project.version}</doctitle>
           <windowtitle>Cloud Runtime Configuration API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-runtimeconfig/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-runtimeconfig/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Runtime Configuration API ${project.version}</doctitle>
           <windowtitle>Cloud Runtime Configuration API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-runtimeconfig/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-runtimeconfig/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Runtime Configuration API ${project.version}</doctitle>
           <windowtitle>Cloud Runtime Configuration API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-runtimeconfig/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-runtimeconfig/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Runtime Configuration API ${project.version}</doctitle>
           <windowtitle>Cloud Runtime Configuration API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-safebrowsing/v4/1.26.0/pom.xml
+++ b/clients/google-api-services-safebrowsing/v4/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Safe Browsing API ${project.version}</doctitle>
           <windowtitle>Safe Browsing API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-safebrowsing/v4/1.27.0/pom.xml
+++ b/clients/google-api-services-safebrowsing/v4/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Safe Browsing API ${project.version}</doctitle>
           <windowtitle>Safe Browsing API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-safebrowsing/v4/1.28.0/pom.xml
+++ b/clients/google-api-services-safebrowsing/v4/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Safe Browsing API ${project.version}</doctitle>
           <windowtitle>Safe Browsing API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-script/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-script/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Apps Script API ${project.version}</doctitle>
           <windowtitle>Apps Script API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-script/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-script/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Apps Script API ${project.version}</doctitle>
           <windowtitle>Apps Script API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-script/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-script/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Apps Script API ${project.version}</doctitle>
           <windowtitle>Apps Script API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-searchconsole/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-searchconsole/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Search Console URL Testing Tools API ${project.version}</doctitle>
           <windowtitle>Google Search Console URL Testing Tools API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-searchconsole/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-searchconsole/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Search Console URL Testing Tools API ${project.version}</doctitle>
           <windowtitle>Google Search Console URL Testing Tools API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-searchconsole/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-searchconsole/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Search Console URL Testing Tools API ${project.version}</doctitle>
           <windowtitle>Google Search Console URL Testing Tools API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-securitycenter/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-securitycenter/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Security Command Center API ${project.version}</doctitle>
           <windowtitle>Cloud Security Command Center API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-securitycenter/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-securitycenter/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Security Command Center API ${project.version}</doctitle>
           <windowtitle>Cloud Security Command Center API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-securitycenter/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-securitycenter/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Security Command Center API ${project.version}</doctitle>
           <windowtitle>Cloud Security Command Center API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-securitycenter/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-securitycenter/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Security Command Center API ${project.version}</doctitle>
           <windowtitle>Cloud Security Command Center API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-securitycenter/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-securitycenter/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Security Command Center API ${project.version}</doctitle>
           <windowtitle>Cloud Security Command Center API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-securitycenter/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-securitycenter/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Security Command Center API ${project.version}</doctitle>
           <windowtitle>Cloud Security Command Center API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-securitycenter/v1p1alpha1/1.26.0/pom.xml
+++ b/clients/google-api-services-securitycenter/v1p1alpha1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Security Command Center API ${project.version}</doctitle>
           <windowtitle>Cloud Security Command Center API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-securitycenter/v1p1alpha1/1.27.0/pom.xml
+++ b/clients/google-api-services-securitycenter/v1p1alpha1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Security Command Center API ${project.version}</doctitle>
           <windowtitle>Cloud Security Command Center API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-securitycenter/v1p1alpha1/1.28.0/pom.xml
+++ b/clients/google-api-services-securitycenter/v1p1alpha1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Security Command Center API ${project.version}</doctitle>
           <windowtitle>Cloud Security Command Center API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-servicebroker/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-servicebroker/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Service Broker API ${project.version}</doctitle>
           <windowtitle>Service Broker API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-servicebroker/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-servicebroker/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Service Broker API ${project.version}</doctitle>
           <windowtitle>Service Broker API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-servicebroker/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-servicebroker/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Service Broker API ${project.version}</doctitle>
           <windowtitle>Service Broker API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-servicebroker/v1alpha1/1.26.0/pom.xml
+++ b/clients/google-api-services-servicebroker/v1alpha1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Service Broker API ${project.version}</doctitle>
           <windowtitle>Service Broker API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-servicebroker/v1alpha1/1.27.0/pom.xml
+++ b/clients/google-api-services-servicebroker/v1alpha1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Service Broker API ${project.version}</doctitle>
           <windowtitle>Service Broker API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-servicebroker/v1alpha1/1.28.0/pom.xml
+++ b/clients/google-api-services-servicebroker/v1alpha1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Service Broker API ${project.version}</doctitle>
           <windowtitle>Service Broker API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-servicebroker/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-servicebroker/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Service Broker API ${project.version}</doctitle>
           <windowtitle>Service Broker API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-servicebroker/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-servicebroker/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Service Broker API ${project.version}</doctitle>
           <windowtitle>Service Broker API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-servicebroker/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-servicebroker/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Service Broker API ${project.version}</doctitle>
           <windowtitle>Service Broker API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-servicecontrol/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-servicecontrol/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Service Control API ${project.version}</doctitle>
           <windowtitle>Service Control API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-servicecontrol/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-servicecontrol/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Service Control API ${project.version}</doctitle>
           <windowtitle>Service Control API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-servicecontrol/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-servicecontrol/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Service Control API ${project.version}</doctitle>
           <windowtitle>Service Control API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-servicemanagement/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-servicemanagement/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Service Management API ${project.version}</doctitle>
           <windowtitle>Service Management API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-servicemanagement/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-servicemanagement/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Service Management API ${project.version}</doctitle>
           <windowtitle>Service Management API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-servicemanagement/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-servicemanagement/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Service Management API ${project.version}</doctitle>
           <windowtitle>Service Management API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-sheets/v4/1.26.0/pom.xml
+++ b/clients/google-api-services-sheets/v4/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Sheets API ${project.version}</doctitle>
           <windowtitle>Google Sheets API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-sheets/v4/1.27.0/pom.xml
+++ b/clients/google-api-services-sheets/v4/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Sheets API ${project.version}</doctitle>
           <windowtitle>Google Sheets API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-sheets/v4/1.28.0/pom.xml
+++ b/clients/google-api-services-sheets/v4/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Sheets API ${project.version}</doctitle>
           <windowtitle>Google Sheets API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-siteVerification/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-siteVerification/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Site Verification API ${project.version}</doctitle>
           <windowtitle>Google Site Verification API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-siteVerification/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-siteVerification/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Site Verification API ${project.version}</doctitle>
           <windowtitle>Google Site Verification API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-siteVerification/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-siteVerification/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Site Verification API ${project.version}</doctitle>
           <windowtitle>Google Site Verification API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-slides/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-slides/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Slides API ${project.version}</doctitle>
           <windowtitle>Google Slides API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-slides/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-slides/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Slides API ${project.version}</doctitle>
           <windowtitle>Google Slides API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-slides/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-slides/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Slides API ${project.version}</doctitle>
           <windowtitle>Google Slides API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-sourcerepo/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-sourcerepo/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Source Repositories API ${project.version}</doctitle>
           <windowtitle>Cloud Source Repositories API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-sourcerepo/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-sourcerepo/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Source Repositories API ${project.version}</doctitle>
           <windowtitle>Cloud Source Repositories API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-sourcerepo/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-sourcerepo/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Source Repositories API ${project.version}</doctitle>
           <windowtitle>Cloud Source Repositories API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-spanner/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-spanner/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Spanner API ${project.version}</doctitle>
           <windowtitle>Cloud Spanner API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-spanner/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-spanner/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Spanner API ${project.version}</doctitle>
           <windowtitle>Cloud Spanner API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-spanner/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-spanner/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Spanner API ${project.version}</doctitle>
           <windowtitle>Cloud Spanner API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-storage/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-storage/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Storage JSON API ${project.version}</doctitle>
           <windowtitle>Cloud Storage JSON API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-storage/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-storage/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Storage JSON API ${project.version}</doctitle>
           <windowtitle>Cloud Storage JSON API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-storage/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-storage/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Storage JSON API ${project.version}</doctitle>
           <windowtitle>Cloud Storage JSON API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-storage/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-storage/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Storage JSON API ${project.version}</doctitle>
           <windowtitle>Cloud Storage JSON API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-storage/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-storage/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Storage JSON API ${project.version}</doctitle>
           <windowtitle>Cloud Storage JSON API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-storage/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-storage/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Storage JSON API ${project.version}</doctitle>
           <windowtitle>Cloud Storage JSON API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-storage/v1beta2/1.26.0/pom.xml
+++ b/clients/google-api-services-storage/v1beta2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Storage JSON API ${project.version}</doctitle>
           <windowtitle>Cloud Storage JSON API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-storage/v1beta2/1.27.0/pom.xml
+++ b/clients/google-api-services-storage/v1beta2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Storage JSON API ${project.version}</doctitle>
           <windowtitle>Cloud Storage JSON API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-storage/v1beta2/1.28.0/pom.xml
+++ b/clients/google-api-services-storage/v1beta2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Storage JSON API ${project.version}</doctitle>
           <windowtitle>Cloud Storage JSON API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-storagetransfer/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-storagetransfer/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Storage Transfer API ${project.version}</doctitle>
           <windowtitle>Storage Transfer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-storagetransfer/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-storagetransfer/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Storage Transfer API ${project.version}</doctitle>
           <windowtitle>Storage Transfer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-storagetransfer/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-storagetransfer/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Storage Transfer API ${project.version}</doctitle>
           <windowtitle>Storage Transfer API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-streetviewpublish/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-streetviewpublish/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Street View Publish API ${project.version}</doctitle>
           <windowtitle>Street View Publish API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-streetviewpublish/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-streetviewpublish/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Street View Publish API ${project.version}</doctitle>
           <windowtitle>Street View Publish API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-streetviewpublish/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-streetviewpublish/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Street View Publish API ${project.version}</doctitle>
           <windowtitle>Street View Publish API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-surveys/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-surveys/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Surveys API ${project.version}</doctitle>
           <windowtitle>Surveys API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-surveys/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-surveys/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Surveys API ${project.version}</doctitle>
           <windowtitle>Surveys API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-surveys/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-surveys/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Surveys API ${project.version}</doctitle>
           <windowtitle>Surveys API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-tagmanager/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-tagmanager/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Tag Manager API ${project.version}</doctitle>
           <windowtitle>Tag Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-tagmanager/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-tagmanager/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Tag Manager API ${project.version}</doctitle>
           <windowtitle>Tag Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-tagmanager/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-tagmanager/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Tag Manager API ${project.version}</doctitle>
           <windowtitle>Tag Manager API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-tagmanager/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-tagmanager/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Tag Manager API ${project.version}</doctitle>
           <windowtitle>Tag Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-tagmanager/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-tagmanager/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Tag Manager API ${project.version}</doctitle>
           <windowtitle>Tag Manager API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-tagmanager/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-tagmanager/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Tag Manager API ${project.version}</doctitle>
           <windowtitle>Tag Manager API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-tasks/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-tasks/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Tasks API ${project.version}</doctitle>
           <windowtitle>Tasks API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-tasks/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-tasks/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Tasks API ${project.version}</doctitle>
           <windowtitle>Tasks API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-tasks/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-tasks/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Tasks API ${project.version}</doctitle>
           <windowtitle>Tasks API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-testing/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-testing/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Testing API ${project.version}</doctitle>
           <windowtitle>Cloud Testing API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-testing/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-testing/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Testing API ${project.version}</doctitle>
           <windowtitle>Cloud Testing API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-testing/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-testing/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Testing API ${project.version}</doctitle>
           <windowtitle>Cloud Testing API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-texttospeech/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-texttospeech/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Text-to-Speech API ${project.version}</doctitle>
           <windowtitle>Cloud Text-to-Speech API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-texttospeech/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-texttospeech/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Text-to-Speech API ${project.version}</doctitle>
           <windowtitle>Cloud Text-to-Speech API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-texttospeech/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-texttospeech/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Text-to-Speech API ${project.version}</doctitle>
           <windowtitle>Cloud Text-to-Speech API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-texttospeech/v1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-texttospeech/v1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Text-to-Speech API ${project.version}</doctitle>
           <windowtitle>Cloud Text-to-Speech API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-texttospeech/v1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-texttospeech/v1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Text-to-Speech API ${project.version}</doctitle>
           <windowtitle>Cloud Text-to-Speech API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-texttospeech/v1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-texttospeech/v1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Text-to-Speech API ${project.version}</doctitle>
           <windowtitle>Cloud Text-to-Speech API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-toolresults/v1beta3/1.26.0/pom.xml
+++ b/clients/google-api-services-toolresults/v1beta3/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Tool Results API ${project.version}</doctitle>
           <windowtitle>Cloud Tool Results API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-toolresults/v1beta3/1.27.0/pom.xml
+++ b/clients/google-api-services-toolresults/v1beta3/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Tool Results API ${project.version}</doctitle>
           <windowtitle>Cloud Tool Results API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-toolresults/v1beta3/1.28.0/pom.xml
+++ b/clients/google-api-services-toolresults/v1beta3/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Tool Results API ${project.version}</doctitle>
           <windowtitle>Cloud Tool Results API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-tpu/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-tpu/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud TPU API ${project.version}</doctitle>
           <windowtitle>Cloud TPU API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-tpu/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-tpu/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud TPU API ${project.version}</doctitle>
           <windowtitle>Cloud TPU API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-tpu/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-tpu/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud TPU API ${project.version}</doctitle>
           <windowtitle>Cloud TPU API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-tpu/v1alpha1/1.26.0/pom.xml
+++ b/clients/google-api-services-tpu/v1alpha1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud TPU API ${project.version}</doctitle>
           <windowtitle>Cloud TPU API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-tpu/v1alpha1/1.27.0/pom.xml
+++ b/clients/google-api-services-tpu/v1alpha1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud TPU API ${project.version}</doctitle>
           <windowtitle>Cloud TPU API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-tpu/v1alpha1/1.28.0/pom.xml
+++ b/clients/google-api-services-tpu/v1alpha1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud TPU API ${project.version}</doctitle>
           <windowtitle>Cloud TPU API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-translate/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-translate/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud Translation API ${project.version}</doctitle>
           <windowtitle>Google Cloud Translation API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-translate/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-translate/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud Translation API ${project.version}</doctitle>
           <windowtitle>Google Cloud Translation API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-translate/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-translate/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Cloud Translation API ${project.version}</doctitle>
           <windowtitle>Google Cloud Translation API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-urlshortener/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-urlshortener/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>URL Shortener API ${project.version}</doctitle>
           <windowtitle>URL Shortener API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-urlshortener/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-urlshortener/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>URL Shortener API ${project.version}</doctitle>
           <windowtitle>URL Shortener API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-urlshortener/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-urlshortener/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>URL Shortener API ${project.version}</doctitle>
           <windowtitle>URL Shortener API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-vision/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-vision/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Vision API ${project.version}</doctitle>
           <windowtitle>Cloud Vision API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-vision/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-vision/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Vision API ${project.version}</doctitle>
           <windowtitle>Cloud Vision API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-vision/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-vision/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Vision API ${project.version}</doctitle>
           <windowtitle>Cloud Vision API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-vision/v1p1beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-vision/v1p1beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Vision API ${project.version}</doctitle>
           <windowtitle>Cloud Vision API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-vision/v1p1beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-vision/v1p1beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Vision API ${project.version}</doctitle>
           <windowtitle>Cloud Vision API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-vision/v1p1beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-vision/v1p1beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Vision API ${project.version}</doctitle>
           <windowtitle>Cloud Vision API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-vision/v1p2beta1/1.26.0/pom.xml
+++ b/clients/google-api-services-vision/v1p2beta1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Vision API ${project.version}</doctitle>
           <windowtitle>Cloud Vision API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-vision/v1p2beta1/1.27.0/pom.xml
+++ b/clients/google-api-services-vision/v1p2beta1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Vision API ${project.version}</doctitle>
           <windowtitle>Cloud Vision API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-vision/v1p2beta1/1.28.0/pom.xml
+++ b/clients/google-api-services-vision/v1p2beta1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Cloud Vision API ${project.version}</doctitle>
           <windowtitle>Cloud Vision API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-webfonts/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-webfonts/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Fonts Developer API ${project.version}</doctitle>
           <windowtitle>Google Fonts Developer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-webfonts/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-webfonts/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Fonts Developer API ${project.version}</doctitle>
           <windowtitle>Google Fonts Developer API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-webfonts/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-webfonts/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Google Fonts Developer API ${project.version}</doctitle>
           <windowtitle>Google Fonts Developer API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-webmasters/v3/1.26.0/pom.xml
+++ b/clients/google-api-services-webmasters/v3/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Search Console API ${project.version}</doctitle>
           <windowtitle>Search Console API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-webmasters/v3/1.27.0/pom.xml
+++ b/clients/google-api-services-webmasters/v3/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Search Console API ${project.version}</doctitle>
           <windowtitle>Search Console API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-webmasters/v3/1.28.0/pom.xml
+++ b/clients/google-api-services-webmasters/v3/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Search Console API ${project.version}</doctitle>
           <windowtitle>Search Console API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-websecurityscanner/v1alpha/1.26.0/pom.xml
+++ b/clients/google-api-services-websecurityscanner/v1alpha/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Web Security Scanner API ${project.version}</doctitle>
           <windowtitle>Web Security Scanner API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-websecurityscanner/v1alpha/1.27.0/pom.xml
+++ b/clients/google-api-services-websecurityscanner/v1alpha/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Web Security Scanner API ${project.version}</doctitle>
           <windowtitle>Web Security Scanner API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-websecurityscanner/v1alpha/1.28.0/pom.xml
+++ b/clients/google-api-services-websecurityscanner/v1alpha/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Web Security Scanner API ${project.version}</doctitle>
           <windowtitle>Web Security Scanner API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-websecurityscanner/v1beta/1.26.0/pom.xml
+++ b/clients/google-api-services-websecurityscanner/v1beta/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Web Security Scanner API ${project.version}</doctitle>
           <windowtitle>Web Security Scanner API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-websecurityscanner/v1beta/1.27.0/pom.xml
+++ b/clients/google-api-services-websecurityscanner/v1beta/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Web Security Scanner API ${project.version}</doctitle>
           <windowtitle>Web Security Scanner API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-websecurityscanner/v1beta/1.28.0/pom.xml
+++ b/clients/google-api-services-websecurityscanner/v1beta/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>Web Security Scanner API ${project.version}</doctitle>
           <windowtitle>Web Security Scanner API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-youtube/v3/1.26.0/pom.xml
+++ b/clients/google-api-services-youtube/v3/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>YouTube Data API ${project.version}</doctitle>
           <windowtitle>YouTube Data API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-youtube/v3/1.27.0/pom.xml
+++ b/clients/google-api-services-youtube/v3/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>YouTube Data API ${project.version}</doctitle>
           <windowtitle>YouTube Data API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-youtube/v3/1.28.0/pom.xml
+++ b/clients/google-api-services-youtube/v3/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>YouTube Data API ${project.version}</doctitle>
           <windowtitle>YouTube Data API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-youtubeAnalytics/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-youtubeAnalytics/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>YouTube Analytics API ${project.version}</doctitle>
           <windowtitle>YouTube Analytics API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-youtubeAnalytics/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-youtubeAnalytics/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>YouTube Analytics API ${project.version}</doctitle>
           <windowtitle>YouTube Analytics API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-youtubeAnalytics/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-youtubeAnalytics/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>YouTube Analytics API ${project.version}</doctitle>
           <windowtitle>YouTube Analytics API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-youtubeAnalytics/v2/1.26.0/pom.xml
+++ b/clients/google-api-services-youtubeAnalytics/v2/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>YouTube Analytics API ${project.version}</doctitle>
           <windowtitle>YouTube Analytics API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-youtubeAnalytics/v2/1.27.0/pom.xml
+++ b/clients/google-api-services-youtubeAnalytics/v2/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>YouTube Analytics API ${project.version}</doctitle>
           <windowtitle>YouTube Analytics API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-youtubeAnalytics/v2/1.28.0/pom.xml
+++ b/clients/google-api-services-youtubeAnalytics/v2/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>YouTube Analytics API ${project.version}</doctitle>
           <windowtitle>YouTube Analytics API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-youtubereporting/v1/1.26.0/pom.xml
+++ b/clients/google-api-services-youtubereporting/v1/1.26.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>YouTube Reporting API ${project.version}</doctitle>
           <windowtitle>YouTube Reporting API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.26.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.26.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.26.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.26.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-youtubereporting/v1/1.27.0/pom.xml
+++ b/clients/google-api-services-youtubereporting/v1/1.27.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>YouTube Reporting API ${project.version}</doctitle>
           <windowtitle>YouTube Reporting API ${project.version}</windowtitle>
           <links>
             <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.27.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.27.0/javadoc/index.html</link>
+            <link>https://googleapis.dev/java/google-http-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.27.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.27.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/clients/google-api-services-youtubereporting/v1/1.28.0/pom.xml
+++ b/clients/google-api-services-youtubereporting/v1/1.28.0/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,13 +73,14 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>YouTube Reporting API ${project.version}</doctitle>
           <windowtitle>YouTube Reporting API ${project.version}</windowtitle>
           <links>
-            <link>http://docs.oracle.com/javase/6/docs/api</link>
-            <link>https://google.github.io/google-http-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-oauth-java-client/releases/1.28.0/javadoc/index.html</link>
-            <link>https://google.github.io/google-api-java-client/releases/1.28.0/javadoc/index.html</link>
+            <link>http://docs.oracle.com/javase/7/docs/api</link>
+            <link>https://googleapis.dev/java/google-http-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-oauth-client/1.28.0/index.html</link>
+            <link>https://googleapis.dev/java/google-api-client/1.28.0/index.html</link>
           </links>
         </configuration>
       </plugin>

--- a/generator/src/googleapis/codegen/languages/java/1.26.0/features.json
+++ b/generator/src/googleapis/codegen/languages/java/1.26.0/features.json
@@ -24,9 +24,9 @@
   },
   "javadoc_links": [ 
     "http://docs.oracle.com/javase/6/docs/api",
-    "https://google.github.io/google-http-java-client/releases/${httpClientLibrary}/javadoc/index.html",
-    "https://google.github.io/google-oauth-java-client/releases/${oauthClientLibrary}/javadoc/index.html",
-    "https://google.github.io/google-api-java-client/releases/${baseClientLibrary}/javadoc/index.html"
+    "https://googleapis.dev/java/google-http-client/${httpClientLibrary}/index.html",
+    "https://googleapis.dev/java/google-oauth-client/${oauthClientLibrary}/index.html",
+    "https://googleapis.dev/java/google-api-client/${baseClientLibrary}/index.html"
   ],
   "requires": [
     {

--- a/generator/src/googleapis/codegen/languages/java/1.26.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.26.0/templates/_pom_xml.tmpl
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,6 +73,7 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>{{ api.title }} ${project.version}</doctitle>
           <windowtitle>{{ api.title }} ${project.version}</windowtitle>
           <links>{% for link in features.javadoc_links %}

--- a/generator/src/googleapis/codegen/languages/java/1.27.0/features.json
+++ b/generator/src/googleapis/codegen/languages/java/1.27.0/features.json
@@ -24,9 +24,9 @@
   },
   "javadoc_links": [
     "http://docs.oracle.com/javase/6/docs/api",
-    "https://google.github.io/google-http-java-client/releases/${httpClientLibrary}/javadoc/index.html",
-    "https://google.github.io/google-oauth-java-client/releases/${oauthClientLibrary}/javadoc/index.html",
-    "https://google.github.io/google-api-java-client/releases/${baseClientLibrary}/javadoc/index.html"
+    "https://googleapis.dev/java/google-http-client/${httpClientLibrary}/index.html",
+    "https://googleapis.dev/java/google-oauth-client/${oauthClientLibrary}/index.html",
+    "https://googleapis.dev/java/google-api-client/${baseClientLibrary}/index.html"
   ],
   "requires": [
     {

--- a/generator/src/googleapis/codegen/languages/java/1.27.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.27.0/templates/_pom_xml.tmpl
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,6 +73,7 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>{{ api.title }} ${project.version}</doctitle>
           <windowtitle>{{ api.title }} ${project.version}</windowtitle>
           <links>{% for link in features.javadoc_links %}

--- a/generator/src/googleapis/codegen/languages/java/1.28.0/features.json
+++ b/generator/src/googleapis/codegen/languages/java/1.28.0/features.json
@@ -23,10 +23,10 @@
     } ]
   },
   "javadoc_links": [
-    "http://docs.oracle.com/javase/6/docs/api",
-    "https://google.github.io/google-http-java-client/releases/${httpClientLibrary}/javadoc/index.html",
-    "https://google.github.io/google-oauth-java-client/releases/${oauthClientLibrary}/javadoc/index.html",
-    "https://google.github.io/google-api-java-client/releases/${baseClientLibrary}/javadoc/index.html"
+    "http://docs.oracle.com/javase/7/docs/api",
+    "https://googleapis.dev/java/google-http-client/${httpClientLibrary}/index.html",
+    "https://googleapis.dev/java/google-oauth-client/${oauthClientLibrary}/index.html",
+    "https://googleapis.dev/java/google-api-client/${baseClientLibrary}/index.html"
   ],
   "requires": [
     {

--- a/generator/src/googleapis/codegen/languages/java/1.28.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.28.0/templates/_pom_xml.tmpl
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,6 +73,7 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>{{ api.title }} ${project.version}</doctitle>
           <windowtitle>{{ api.title }} ${project.version}</windowtitle>
           <links>{% for link in features.javadoc_links %}

--- a/generator/src/googleapis/codegen/languages/java/default/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/default/templates/_pom_xml.tmpl
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -73,6 +73,7 @@
           </execution>
         </executions>
         <configuration>
+          <doclint>none</doclint>
           <doctitle>{{ api.title }} ${project.version}</doctitle>
           <windowtitle>{{ api.title }} ${project.version}</windowtitle>
           <links>{% for link in features.javadoc_links %}


### PR DESCRIPTION
* Updates maven-javadoc-plugin to 3.1.0
* Sets doclint to none
* Fixes javadoc links to use googleapis.dev