### PR TITLE
Provide a correct URL for the API explorer

### DIFF
--- a/clients/google-api-services-youtube/v3/README.md
+++ b/clients/google-api-services-youtube/v3/README.md
@@ -41,4 +41,4 @@ dependencies {
 
 [javadoc]: https://googleapis.dev/java/google-api-services-youtube/latest/index.html
 [google-api-client]: https://github.com/googleapis/google-api-java-client/
-[api-explorer]: https://developers.google.com/apis-explorer/#p/youtube/v1/
+[api-explorer]: https://developers.google.com/youtube/v3/docs/


### PR DESCRIPTION
The v3 API explorer is now integrated into the docs, so there isn't a more specific URL AFAICT.