### PR TITLE
Add link to google-auth-library-java

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ packages on [Maven Central][maven-search].
 
 ## Authentication
 
-google-api-java uses https://github.com/googleapis/google-auth-library-java to authenticate requests. google-auth-library-java supports a wide range of authentication types; see the project's README and javadoc for more details.
+google-api-java recommends using the [google-auth-library-java](google-auth-library-java) library to authenticate requests. google-auth-library-java supports a wide range of authentication types; see the [project's README](google-auth-library-java#google-auth-library) and [javadoc](https://googleapis.dev/java/google-auth-library/latest/) for more details.
 
 ## Generating the API clients
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Google Java API Client Services
 
 This repository contains the generated source for individual APIs that utilize
-[Google APIs Client Library for Java][google-api-java-client].
+[Google APIs Client Library for Java][google-api-java-client].  We recommend using the
+[Google Auth Library for Java](google-auth-library-java) for handling authentication.
 
 ## Requirements
 
@@ -191,6 +192,10 @@ packages on [Maven Central][maven-search].
 | YouTube Reporting API | [v1](clients/google-api-services-youtubereporting/v1) |
 
 [//]: # (API_TABLE_END)
+
+## Authentication
+
+google-api-java uses https://github.com/googleapis/google-auth-library-java to authenticate requests. google-auth-library-java supports a wide range of authentication types; see the project's README and javadoc for more details.
 
 ## Generating the API clients
 


### PR DESCRIPTION
There are several pages that point to this README.md for documentation, but it's unclear what is the best way to perform authentication.  Web searches push towards [google-oauth-java-client](google-oauth-java-client) library which is now in maintenance mode.