### PR TITLE
feat: add script for easy self-serve client generation

### DIFF
--- a/generator/generate.sh
+++ b/generator/generate.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+if [[ $# -lt 2 ]]
+then
+    echo "Usage: $0 <path/to/discovery.json> <output-directory>"
+    exit 1
+fi
+
+GENERATOR_DIR=$(dirname $0 | xargs realpath)
+DISCOVERY=$1
+OUTPUT_DIR=$(realpath $2)
+
+# if discovery is a URL, download it to a temp file
+if [[ ${DISCOVERY} = http* ]]
+then
+    TEMP_DISCOVERY=$(mktemp -t discovery-XXXXXXXXXX.json)
+    echo "Downloading remote discovery ${DISCOVERY} to ${TEMP_DISCOVERY}"
+    curl -sL "${DISCOVERY}" -o ${TEMP_DISCOVERY}
+    DISCOVERY=${TEMP_DISCOVERY}
+fi
+
+# install the local generators
+python2 -m pip install -e ${GENERATOR_DIR} --user -q
+
+mkdir -p ${OUTPUT_DIR}
+
+# run the local generator
+python2 -m googleapis.codegen \
+    --output_dir=${OUTPUT_DIR} \
+    --input=${DISCOVERY} \
+    --language=java \
+    --language_variant=1.30.1 \
+    --package_path=api/services
+
+echo "Wrote client to ${OUTPUT_DIR}"


### PR DESCRIPTION
Creates a bash script in the generator directory to make it easy to self-serve discovery client generation.

Usage:

1. Clone this repository
2. Run the generate.sh script:

```bash
# generate the source code
generator/generate.sh <discovery> <output-directory>
```

3. compile the jar:
```bash
# compile the jar
cd <output-directory>
mvn package
```

The output jar will be available in `<output-directory>/target`


The `discovery` option can either be a path to the json discovery file or a url to fetch from. The client will be generated in the `output-directory`.

Note that the generator still requires python2.