### PR TITLE
add mtls endpoint fallback

### DIFF
--- a/generator/src/googleapis/codegen/languages/java/1.31.0/templates/___package___/___api_className___.java.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.31.0/templates/___package___/___api_className___.java.tmpl
@@ -144,7 +144,11 @@ public class {{ api.className }} extends com.google.api.client.googleapis.servic
       String useMtlsEndpoint = System.getenv("GOOGLE_API_USE_MTLS_ENDPOINT");
       useMtlsEndpoint = useMtlsEndpoint == null ? "auto" : useMtlsEndpoint;
       if ("always".equals(useMtlsEndpoint) || ("auto".equals(useMtlsEndpoint) && transport != null && transport.isMtls())) {
-        return DEFAULT_MTLS_ROOT_URL;
+        // Use regex to create the mtls endpoint in case it's missing from the discovery doc.
+        if (!DEFAULT_MTLS_ROOT_URL.isEmpty()) {
+          return DEFAULT_MTLS_ROOT_URL;
+        }
+        return DEFAULT_ROOT_URL.replace("googleapis.com", "mtls.googleapis.com");
       }
       return DEFAULT_ROOT_URL;
     }


### PR DESCRIPTION
use regex to add the mtls endpoint as a fallback, in case mtls endpoint is missing from discovery doc (for instance, compute api)