### PR TITLE
build(generator): add mtls endpoint fallback and update synth.py template version

### DIFF
--- a/generator/src/googleapis/codegen/api.py
+++ b/generator/src/googleapis/codegen/api.py
@@ -330,6 +330,10 @@ class Api(template_objects.CodeObject):
       self._api.SetTemplateValue('rootUrl', '%s://%s/' % (scheme, service_host))
     if service_path is None:
       self._api.SetTemplateValue('servicePath', base_path[1:])
+    
+    if not self.values.get('mtlsRootUrl') and root_url:
+      mtls_root_url = root_url.replace('googleapis.com', 'mtls.googleapis.com')
+      self._api.SetTemplateValue('mtlsRootUrl', mtls_root_url)
 
     # Make sure template writers do not revert
     self._api.DeleteTemplateValue('baseUrl')

--- a/generator/src/googleapis/codegen/api.py
+++ b/generator/src/googleapis/codegen/api.py
@@ -331,6 +331,7 @@ class Api(template_objects.CodeObject):
     if service_path is None:
       self._api.SetTemplateValue('servicePath', base_path[1:])
     
+    # TODO(sijunliu): remove this once mtlsRootUrl is available in all services.
     if not self.values.get('mtlsRootUrl') and root_url:
       mtls_root_url = root_url.replace('googleapis.com', 'mtls.googleapis.com')
       self._api.SetTemplateValue('mtlsRootUrl', mtls_root_url)

--- a/generator/tests/api_test.py
+++ b/generator/tests/api_test.py
@@ -443,6 +443,17 @@ class ApiTest(basetest.TestCase):
                       api.values['rootUrl'])
     self.assertEquals('fake/v1/', api.values['servicePath'])
 
+    # Test mTLS endpoint
+    api = LoadApi({'mtlsRootUrl': 'https://foo.mtls.com'})
+    self.assertEquals('https://foo.mtls.com', api.values['mtlsRootUrl'])
+
+    # Test if mtlsRootUrl is missing, then regex is used to create a mTLS endpoint
+    api = LoadApi({
+        'rootUrl': 'https://foo.googleapis.com',
+        'servicePath': 'fake/v1/',
+    })
+    self.assertEquals('https://foo.mtls.googleapis.com', api.values['mtlsRootUrl'])
+
     # .. in path
     self.assertRaises(ValueError, LoadApi, {'basePath': '/do/not/../go/up'})
 

--- a/synth.py
+++ b/synth.py
@@ -34,7 +34,7 @@ logging.basicConfig(level=logging.DEBUG)
 VERSION_REGEX = r"([^\.]*)\.(.+)\.json$"
 
 TEMPLATE_VERSIONS = [
-    "1.30.1",
+    "1.31.0",
 ]
 discovery_url = "https://github.com/googleapis/discovery-artifact-manager.git"
 


### PR DESCRIPTION
- use regex to generate mtls endpoint if `mtlsRootUrl` is missing from discovery doc
- update the template version in synth.py to generate 1.31.0 client libraries