### PR TITLE
Update README.md

### DIFF
--- a/clients/google-api-services-youtube/v3/README.md
+++ b/clients/google-api-services-youtube/v3/README.md
@@ -35,7 +35,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  compile 'com.google.apis:google-api-services-youtube:v3-rev20210915-1.32.1'
+  implementation 'com.google.apis:google-api-services-youtube:v3-rev20210915-1.32.1'
 }
 ```
 


### PR DESCRIPTION
https://stackoverflow.com/questions/23796404/could-not-find-method-compile-for-arguments-gradle

https://docs.gradle.org/4.10/userguide/java_plugin.html#sec:java_plugin_and_dependency_management

compile in gradle has been deprecated. Replace with implementation 