### PR TITLE
build: fix version parsing

### DIFF
--- a/.github/workflows/generate.sh
+++ b/.github/workflows/generate.sh
@@ -38,7 +38,7 @@ pushd ${ROOT_DIR}/discovery-artifact-manager
 
 for DISCOVERY in `ls discoveries/${SERVICE}.*.json`
 do
-  VERSION=$(basename ${DISCOVERY} | cut -d. -f2)
+  VERSION=$(basename ${DISCOVERY} | sed 's/\.json//' | cut -d. -f2-)
   OUTPUT_DIR=${ROOT_DIR}/google-api-java-client-services/clients/google-api-services-${SERVICE}/${VERSION}/${VARIANT}
   echo ${DISCOVERY}
   echo ${VERSION}


### PR DESCRIPTION
`adsensehost.v4.1.json` was being parsed as `v4` when it should have been `v4.1`

This change strips off the trailing `.json` and then splits on `.` and returns the second token and beyond