### PR TITLE
build: update template to match compiler and api client version

### DIFF
--- a/generator/src/googleapis/codegen/languages/java/1.31.0/features.json
+++ b/generator/src/googleapis/codegen/languages/java/1.31.0/features.json
@@ -3,7 +3,7 @@
   "description": "Java libraries for Google APIs.",
   "generator": "java1_15",
   "releaseVersion": "1.32.1",
-  "baseClientLibrary": "1.33.0",
+  "baseClientLibrary": "1.33.1",
   "oauthClientLibrary": "1.31.2",
   "httpClientLibrary": "1.41.0",
   "gsonVersion": "2.8.6",

--- a/generator/src/googleapis/codegen/languages/java/1.31.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.31.0/templates/_pom_xml.tmpl
@@ -38,7 +38,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.9.1</version>
+        <version>3.9.0</version>
         <configuration>
           <source>1.7</source>
           <target>1.7</target>

--- a/generator/src/googleapis/codegen/languages/java/1.31.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.31.0/templates/_pom_xml.tmpl
@@ -38,7 +38,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.9.1</version>
         <configuration>
           <source>1.7</source>
           <target>1.7</target>


### PR DESCRIPTION
This should prevent us having 200+ PRs to revert versions