### PR TITLE
build: disable renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "enabled": false
+}


### PR DESCRIPTION
We should not be using renovate to bump dependency versions.

Dependency versions are managed by templates and will be reverted by codegen if we update via renovate.