### PR TITLE
chore: use 'implementation' instead of 'compile' for dependencies

### DIFF
--- a/generator/src/googleapis/codegen/languages/java/1.31.0/templates/README.md.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.31.0/templates/README.md.tmpl
@@ -35,7 +35,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  compile '{{ api.maven.group_id }}:{{ api.maven.artifact_id }}:{{ api.maven.version }}'
+  implementation '{{ api.maven.group_id }}:{{ api.maven.artifact_id }}:{{ api.maven.version }}'
 }
 ```
 

--- a/generator/src/googleapis/codegen/languages/java/default/templates/README.md.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/default/templates/README.md.tmpl
@@ -35,7 +35,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  compile '{{ api.maven.group_id }}:{{ api.maven.artifact_id }}:{{ api.maven.version }}'
+  implementation '{{ api.maven.group_id }}:{{ api.maven.artifact_id }}:{{ api.maven.version }}'
 }
 ```
 


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-api-java-client-services/issues/9537