### PR TITLE
chore: update javadoc link

### DIFF
--- a/clients/google-api-services-admin/datatransfer_v1/1.30.1/README.md
+++ b/clients/google-api-services-admin/datatransfer_v1/1.30.1/README.md
@@ -6,7 +6,7 @@ This page contains information about getting started with the Admin Data Transfe
 using the Google API Client Library for Java. In addition, you may be interested
 in the following documentation:
 
-* Browse the [Javadoc reference for the Admin Data Transfer API][javadoc]
+* Use dropdown to browse the [Javadoc reference for the Admin Data Transfer API][javadoc]
 * Read the [Developer's Guide for the Google API Client Library for Java][google-api-client].
 * Interact with this API in your browser using the [APIs Explorer for the Admin Data Transfer API][api-explorer]
 
@@ -39,6 +39,6 @@ dependencies {
 }
 ```
 
-[javadoc]: https://googleapis.dev/java/google-api-services-admin-datatransfer/latest/index.html
+[javadoc]: https://googleapis.dev/java/google-api-services-admin/latest/index.html
 [google-api-client]: https://github.com/googleapis/google-api-java-client/
 [api-explorer]: https://developers.google.com/apis-explorer/#p/admin/v1/

--- a/clients/google-api-services-admin/datatransfer_v1/1.31.0/README.md
+++ b/clients/google-api-services-admin/datatransfer_v1/1.31.0/README.md
@@ -6,7 +6,7 @@ This page contains information about getting started with the Admin SDK API
 using the Google API Client Library for Java. In addition, you may be interested
 in the following documentation:
 
-* Browse the [Javadoc reference for the Admin SDK API][javadoc]
+* Use dropdown to browse the [Javadoc reference for the Admin SDK API][javadoc]
 * Read the [Developer's Guide for the Google API Client Library for Java][google-api-client].
 * Interact with this API in your browser using the [APIs Explorer for the Admin SDK API][api-explorer]
 
@@ -39,6 +39,6 @@ dependencies {
 }
 ```
 
-[javadoc]: https://googleapis.dev/java/google-api-services-admin-datatransfer/latest/index.html
+[javadoc]: https://googleapis.dev/java/google-api-services-admin/latest/index.html
 [google-api-client]: https://github.com/googleapis/google-api-java-client/
 [api-explorer]: https://developers.google.com/apis-explorer/#p/admin/v1/

--- a/clients/google-api-services-admin/datatransfer_v1/README.md
+++ b/clients/google-api-services-admin/datatransfer_v1/README.md
@@ -6,7 +6,7 @@ This page contains information about getting started with the Admin SDK API
 using the Google API Client Library for Java. In addition, you may be interested
 in the following documentation:
 
-* Browse the [Javadoc reference for the Admin SDK API][javadoc]
+* Use dropdown to browse the [Javadoc reference for the Admin SDK API][javadoc].
 * Read the [Developer's Guide for the Google API Client Library for Java][google-api-client].
 * Interact with this API in your browser using the [APIs Explorer for the Admin SDK API][api-explorer]
 
@@ -39,6 +39,6 @@ dependencies {
 }
 ```
 
-[javadoc]: https://googleapis.dev/java/google-api-services-admin-datatransfer/latest/index.html
+[javadoc]: https://googleapis.dev/java/google-api-services-admin/latest/index.html
 [google-api-client]: https://github.com/googleapis/google-api-java-client/
 [api-explorer]: https://developers.google.com/apis-explorer/#p/admin/v1/

--- a/clients/google-api-services-admin/directory_v1/1.30.1/README.md
+++ b/clients/google-api-services-admin/directory_v1/1.30.1/README.md
@@ -39,6 +39,6 @@ dependencies {
 }
 ```
 
-[javadoc]: https://googleapis.dev/java/google-api-services-admin-directory/latest/index.html
+[javadoc]: https://googleapis.dev/java/google-api-services-admin/latest/index.html
 [google-api-client]: https://github.com/googleapis/google-api-java-client/
 [api-explorer]: https://developers.google.com/apis-explorer/#p/admin/v1/

--- a/clients/google-api-services-admin/directory_v1/1.30.1/README.md
+++ b/clients/google-api-services-admin/directory_v1/1.30.1/README.md
@@ -6,7 +6,7 @@ This page contains information about getting started with the Admin Directory AP
 using the Google API Client Library for Java. In addition, you may be interested
 in the following documentation:
 
-* Browse the [Javadoc reference for the Admin Directory API][javadoc]
+* Use dropdown to browse the [Javadoc reference for the Admin Directory API][javadoc]
 * Read the [Developer's Guide for the Google API Client Library for Java][google-api-client].
 * Interact with this API in your browser using the [APIs Explorer for the Admin Directory API][api-explorer]
 

--- a/clients/google-api-services-admin/directory_v1/1.31.0/README.md
+++ b/clients/google-api-services-admin/directory_v1/1.31.0/README.md
@@ -6,7 +6,7 @@ This page contains information about getting started with the Admin SDK API
 using the Google API Client Library for Java. In addition, you may be interested
 in the following documentation:
 
-* Browse the [Javadoc reference for the Admin SDK API][javadoc]
+* Use dropdown to browse the [Javadoc reference for the Admin SDK API][javadoc]
 * Read the [Developer's Guide for the Google API Client Library for Java][google-api-client].
 * Interact with this API in your browser using the [APIs Explorer for the Admin SDK API][api-explorer]
 
@@ -39,6 +39,6 @@ dependencies {
 }
 ```
 
-[javadoc]: https://googleapis.dev/java/google-api-services-admin-directory/latest/index.html
+[javadoc]: https://googleapis.dev/java/google-api-services-admin/latest/index.html
 [google-api-client]: https://github.com/googleapis/google-api-java-client/
 [api-explorer]: https://developers.google.com/apis-explorer/#p/admin/v1/

--- a/clients/google-api-services-admin/directory_v1/README.md
+++ b/clients/google-api-services-admin/directory_v1/README.md
@@ -6,7 +6,7 @@ This page contains information about getting started with the Admin SDK API
 using the Google API Client Library for Java. In addition, you may be interested
 in the following documentation:
 
-* Browse the [Javadoc reference for the Admin SDK API][javadoc]
+* Use dropdown to browse the [Javadoc reference for the Admin SDK API][javadoc]
 * Read the [Developer's Guide for the Google API Client Library for Java][google-api-client].
 * Interact with this API in your browser using the [APIs Explorer for the Admin SDK API][api-explorer]
 
@@ -39,6 +39,6 @@ dependencies {
 }
 ```
 
-[javadoc]: https://googleapis.dev/java/google-api-services-admin-directory/latest/index.html
+[javadoc]: https://googleapis.dev/java/google-api-services-admin/latest/index.html
 [google-api-client]: https://github.com/googleapis/google-api-java-client/
 [api-explorer]: https://developers.google.com/apis-explorer/#p/admin/v1/

--- a/clients/google-api-services-admin/reports_v1/1.30.1/README.md
+++ b/clients/google-api-services-admin/reports_v1/1.30.1/README.md
@@ -6,7 +6,7 @@ This page contains information about getting started with the Admin Reports API
 using the Google API Client Library for Java. In addition, you may be interested
 in the following documentation:
 
-* Browse the [Javadoc reference for the Admin Reports API][javadoc]
+* Use dropdown to browse the [Javadoc reference for the Admin Reports API][javadoc]
 * Read the [Developer's Guide for the Google API Client Library for Java][google-api-client].
 * Interact with this API in your browser using the [APIs Explorer for the Admin Reports API][api-explorer]
 
@@ -39,6 +39,6 @@ dependencies {
 }
 ```
 
-[javadoc]: https://googleapis.dev/java/google-api-services-admin-reports/latest/index.html
+[javadoc]: https://googleapis.dev/java/google-api-services-admin/latest/index.html
 [google-api-client]: https://github.com/googleapis/google-api-java-client/
 [api-explorer]: https://developers.google.com/apis-explorer/#p/admin/v1/

--- a/clients/google-api-services-admin/reports_v1/1.31.0/README.md
+++ b/clients/google-api-services-admin/reports_v1/1.31.0/README.md
@@ -6,7 +6,7 @@ This page contains information about getting started with the Admin SDK API
 using the Google API Client Library for Java. In addition, you may be interested
 in the following documentation:
 
-* Browse the [Javadoc reference for the Admin SDK API][javadoc]
+* Use dropdown to browse the [Javadoc reference for the Admin SDK API][javadoc]
 * Read the [Developer's Guide for the Google API Client Library for Java][google-api-client].
 * Interact with this API in your browser using the [APIs Explorer for the Admin SDK API][api-explorer]
 
@@ -39,6 +39,6 @@ dependencies {
 }
 ```
 
-[javadoc]: https://googleapis.dev/java/google-api-services-admin-reports/latest/index.html
+[javadoc]: https://googleapis.dev/java/google-api-services-admin/latest/index.html
 [google-api-client]: https://github.com/googleapis/google-api-java-client/
 [api-explorer]: https://developers.google.com/apis-explorer/#p/admin/v1/

--- a/clients/google-api-services-admin/reports_v1/README.md
+++ b/clients/google-api-services-admin/reports_v1/README.md
@@ -6,7 +6,7 @@ This page contains information about getting started with the Admin SDK API
 using the Google API Client Library for Java. In addition, you may be interested
 in the following documentation:
 
-* Browse the [Javadoc reference for the Admin SDK API][javadoc]
+* Use dropdown to browse the [Javadoc reference for the Admin SDK API][javadoc]
 * Read the [Developer's Guide for the Google API Client Library for Java][google-api-client].
 * Interact with this API in your browser using the [APIs Explorer for the Admin SDK API][api-explorer]
 
@@ -39,6 +39,6 @@ dependencies {
 }
 ```
 
-[javadoc]: https://googleapis.dev/java/google-api-services-admin-reports/latest/index.html
+[javadoc]: https://googleapis.dev/java/google-api-services-admin/latest/index.html
 [google-api-client]: https://github.com/googleapis/google-api-java-client/
 [api-explorer]: https://developers.google.com/apis-explorer/#p/admin/v1/


### PR DESCRIPTION
Fixes #6100

These are all getting uploaded with the name 'google-api-services-admin' and differentiate on version. If you look at the dropdown at [googleapis.dev/java/google-api-services-admin/latest/index.html](https://googleapis.dev/java/google-api-services-admin/latest/index.html) you can see they exist as different versions. We'd have to configure this differently to make it work https://github.com/googleapis/google-api-java-client-services/blob/main/.kokoro/release.sh#L60 and I'm not sure it's worth it for apiary. It's annoying because you can't just link to latest, you have to link to the specific version.

Since they are all grouped together the latest is getting chosen as the reports one likely because it has the highest number. These pages exist, just a little confusing to navigate. Solution is to link to google-api-services-admin/latest and update the text to mention the dropdown. We can reevaluate if we continue to see issues around this, but no link will 404 anymore.
