### PR TITLE
build: generate.sh to use variant "2.0.0"

### DIFF
--- a/.github/workflows/generate.sh
+++ b/.github/workflows/generate.sh
@@ -28,7 +28,7 @@ fi
 
 if [[ -z "${VARIANT}" ]]
 then
-  VARIANT=1.31.0
+  VARIANT=2.0.0
 fi
 
 # install the local generators


### PR DESCRIPTION
It seems that the template directory "2.0.0" is unused yet in the codegen job https://github.com/googleapis/google-api-java-client-services/runs/7602652259?check_suite_focus=true.

<img width="913" alt="Screen Shot 2022-08-01 at 9 31 55 AM" src="https://user-images.githubusercontent.com/28604/182159514-ee1042b6-c242-45e8-ac6b-ab04547a067b.png">

