### PR TITLE
docs: updating google-auth-library links

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,10 +257,10 @@ packages on [Maven Central][maven-search].
 ## Authentication
 
 google-api-java recommends using the [google-auth-library-java][google-auth-library-java]
-library to authenticate requests. google-auth-library-java supports a wide range of authentication types;
+library to authenticate HTTPS requests. google-auth-library-java supports a wide range of authentication types;
 see the [project's README](https://github.com/googleapis/google-auth-library-java#using-credentials-with-google-http-client)
-for how to use authenticated and [javadoc](https://cloud.google.com/java/docs/reference/google-auth-library/latest/overview)
-for more details.
+for how to use authenticated requests and
+[javadoc](https://cloud.google.com/java/docs/reference/google-auth-library/latest/overview) for more details.
 
 ## Generating the API clients
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ packages on [Maven Central][maven-search].
 google-api-java recommends using the [google-auth-library-java][google-auth-library-java]
 library to authenticate HTTPS requests. google-auth-library-java supports a wide range of authentication types;
 see the [project's README](https://github.com/googleapis/google-auth-library-java#using-credentials-with-google-http-client)
-for how to use authenticated requests and
+for how to use credentials with google-http-client and
 [javadoc](https://cloud.google.com/java/docs/reference/google-auth-library/latest/overview) for more details.
 
 ## Generating the API clients

--- a/README.md
+++ b/README.md
@@ -256,7 +256,11 @@ packages on [Maven Central][maven-search].
 
 ## Authentication
 
-google-api-java recommends using the [google-auth-library-java][google-auth-library-java] library to authenticate requests. google-auth-library-java supports a wide range of authentication types; see the [project's README](https://github.com/googleapis/google-auth-library-java#google-auth-library) and [javadoc](https://googleapis.dev/java/google-auth-library/latest/) for more details.
+google-api-java recommends using the [google-auth-library-java][google-auth-library-java]
+library to authenticate requests. google-auth-library-java supports a wide range of authentication types;
+see the [project's README](https://github.com/googleapis/google-auth-library-java#using-credentials-with-google-http-client)
+for how to use authenticated and [javadoc](https://cloud.google.com/java/docs/reference/google-auth-library/latest/overview)
+for more details.
 
 ## Generating the API clients
 


### PR DESCRIPTION
The other day, I found it difficult to setup authentication but the authentication library has the exact code I wanted to learn.

- The link should point to the authentication with google-http-client
- The API documentation is now at https://cloud.google.com/java/docs/reference/google-auth-library/latest/overview.