### PR TITLE
ci: fixing GitHub Actions python version

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -30,7 +30,7 @@ jobs:
           path: discovery-artifact-manager
       - uses: actions/setup-python@v2
         with:
-          python-version: 2.7
+          python-version: 2.7.18
       - run: ./google-api-java-client-services/.github/workflows/generate.sh ${{ matrix.service }}
       - uses: googleapis/code-suggester@v2 # takes the changes from git directory
         env:


### PR DESCRIPTION
The codegen job has been failing due to 

> Error: Version 2.7 with arch x64 not found
> The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json

Version 2.7.18 is available as per  https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json

Fixes https://github.com/googleapis/google-api-java-client-services/issues/13409

