### PR TITLE
fix: generate batches at separate times

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -36,7 +36,7 @@ jobs:
     needs: batch
     if: ${{fromJson(needs.batch.outputs.services).isEvenHour}}
     steps:
-      - uses: google-api-java-client-services/generate
+      - uses: google-api-java-client-services/generate.yaml@matrix-fix-2
         with: 
           services: fromJson(needs.batch.outputs.services).one
   generate_two:
@@ -44,6 +44,6 @@ jobs:
     needs: batch
     if: ${{!fromJson(needs.batch.outputs.services).isEvenHour}}
     steps:
-      - uses: google-api-java-client-services/generate
+      - uses: google-api-java-client-services/generate.yaml@matrix-fix-2
         with: 
           services: fromJson(needs.batch.outputs.services).two

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -36,6 +36,7 @@ jobs:
     needs: batch
     if: ${{fromJson(needs.batch.outputs.services).isEvenHour}}
     steps:
+      - uses: actions/checkout@v3
       - uses: googleapis/google-api-java-client-services/generate.yaml@matrix-fix-2
         with: 
           services: fromJson(needs.batch.outputs.services).one
@@ -44,6 +45,7 @@ jobs:
     needs: batch
     if: ${{!fromJson(needs.batch.outputs.services).isEvenHour}}
     steps:
+      - uses: actions/checkout@v3
       - uses: googleapis/google-api-java-client-services/generate.yaml@matrix-fix-2
         with: 
           services: fromJson(needs.batch.outputs.services).two

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -8,6 +8,20 @@ name: codegen
 jobs:
   discovery:
     uses: googleapis/discovery-artifact-manager/.github/workflows/list-services.yml@master
+  total_service_size_check:
+    runs-on: ubuntu-20.04
+    needs: discovery
+    steps:
+      - uses: actions/github-script@v5
+        id: chunk
+        with:
+          script: |
+            console.log('checking size of services')
+            const MAX_SERVICE_SIZE = 400 // 00:30 to 03:30 implies 4 batches of size 100
+            const services = ${{ needs.discovery.outputs.services }}
+            if (services.length > MAX_SERVICE_SIZE) {
+              throw new Error(`Total services (${services.length}) exceed limit of ${MAX_SERVICE_SIZE}`)
+            }
   batch:
     runs-on: ubuntu-20.04
     needs: discovery

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -31,7 +31,7 @@ jobs:
             }
             return result
   generate:
-    uses: googleapis/google-api-java-client-services/.github/workflows/generate.yaml@matrix-fix-2
+    uses: googleapis/google-api-java-client-services/.github/workflows/generate.yaml@master
     needs: batch
     if: ${{!!fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour]}}
     with: 

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -1,7 +1,7 @@
 on:
   schedule:
     # daily at 12:30 am
-    - cron: '30 0 * * *'
+    - cron: '30 0,1 * * *'
   workflow_dispatch:
 
 name: codegen
@@ -20,9 +20,11 @@ jobs:
           script: |
             console.log('splitting service names list into batches')
             const services = ${{ needs.discovery.outputs.services }}
+            const hour = new Date().getHours()
             const result = {
               "one": [],
               "two": [],
+              "isEvenHour": hour % 2 == 0,
             };
             for (let i = 0; i < services.length; i++) {
               resultBatchKey = i % 2 ? "one" : "two";
@@ -32,76 +34,16 @@ jobs:
   generate_one:
     runs-on: ubuntu-20.04
     needs: batch
-    strategy:
-      fail-fast: false
-      max-parallel: 4
-      matrix: 
-        service: ${{fromJson(needs.batch.outputs.services).one}}
+    if: ${{fromJson(needs.batch.outputs.services).isEvenHour}}
     steps:
-      - run: echo generating ${{ matrix.service }}
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-          path: google-api-java-client-services
-      - uses: actions/checkout@v2
-        with:
-          repository: googleapis/discovery-artifact-manager
-          fetch-depth: 1
-          path: discovery-artifact-manager
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 2.7.18
-      - run: ./google-api-java-client-services/.github/workflows/generate.sh ${{ matrix.service }}
-      - uses: googleapis/code-suggester@v2 # takes the changes from git directory
-        env:
-          ACCESS_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-        with:
-          command: pr
-          upstream_owner: ${{ github.repository_owner }}
-          upstream_repo: google-api-java-client-services
-          description: 'Generated in GitHub action: https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/workflows/codegen.yaml'
-          title: 'chore: regenerate ${{ matrix.service }} client'
-          message: 'chore: regenerate ${{ matrix.service }} client'
-          branch: regenerate-${{ matrix.service }}
-          git_dir: 'google-api-java-client-services/clients/google-api-services-${{ matrix.service }}'
-          primary: main
-          force: true
-          fork: true
+      - uses: google-api-java-client-services/generate
+        with: 
+          services: fromJson(needs.batch.outputs.services).one
   generate_two:
     runs-on: ubuntu-20.04
     needs: batch
-    strategy:
-      fail-fast: false
-      max-parallel: 4
-      matrix: 
-        service: ${{fromJson(needs.batch.outputs.services).two}}
+    if: ${{!fromJson(needs.batch.outputs.services).isEvenHour}}
     steps:
-      - run: echo generating ${{ matrix.service }}
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-          path: google-api-java-client-services
-      - uses: actions/checkout@v2
-        with:
-          repository: googleapis/discovery-artifact-manager
-          fetch-depth: 1
-          path: discovery-artifact-manager
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 2.7.18
-      - run: ./google-api-java-client-services/.github/workflows/generate.sh ${{ matrix.service }}
-      - uses: googleapis/code-suggester@v2 # takes the changes from git directory
-        env:
-          ACCESS_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-        with:
-          command: pr
-          upstream_owner: ${{ github.repository_owner }}
-          upstream_repo: google-api-java-client-services
-          description: 'Generated in GitHub action: https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/workflows/codegen.yaml'
-          title: 'chore: regenerate ${{ matrix.service }} client'
-          message: 'chore: regenerate ${{ matrix.service }} client'
-          branch: regenerate-${{ matrix.service }}
-          git_dir: 'google-api-java-client-services/clients/google-api-services-${{ matrix.service }}'
-          primary: main
-          force: true
-          fork: true
+      - uses: google-api-java-client-services/generate
+        with: 
+          services: fromJson(needs.batch.outputs.services).two

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -1,7 +1,7 @@
 on:
   schedule:
-    # daily at 12:30 am
-    - cron: '30 * * * *'
+    # every one hour from 00:30 to 03:30
+    - cron: '30 0-3 * * *'
   workflow_dispatch:
 
 name: codegen
@@ -33,7 +33,6 @@ jobs:
   generate:
     uses: googleapis/google-api-java-client-services/.github/workflows/generate.yaml@matrix-fix-2
     needs: batch
-    # if: ${{!!fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour]}}
+    if: ${{!!fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour]}}
     with: 
-      # services: ${{toJson(fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour])}}
-      services: ${{toJson(fromJson(needs.batch.outputs.services).batches[0])}}
+      services: ${{toJson(fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour])}}

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -33,7 +33,7 @@ jobs:
   generate:
     uses: googleapis/google-api-java-client-services/.github/workflows/generate.yaml@matrix-fix-2
     needs: batch
-    if: ${{!!fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour]}}
+    # if: ${{!!fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour]}}
     with: 
       # services: ${{fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour]}}
       services: ${{fromJson(needs.batch.outputs.services).batches[0]}}

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -35,5 +35,5 @@ jobs:
     needs: batch
     # if: ${{!!fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour]}}
     with: 
-      # services: ${{fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour]}}
-      services: ${{fromJson(needs.batch.outputs.services).batches[0]}}
+      # services: ${{toJson(fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour])}}
+      services: ${{toJson(fromJson(needs.batch.outputs.services).batches[0])}}

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -31,11 +31,9 @@ jobs:
             }
             return result
   generate:
-    runs-on: ubuntu-20.04
+    uses: googleapis/google-api-java-client-services/.github/workflows/generate.yaml@matrix-fix-2
     needs: batch
     if: ${{!!fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour]}}
-    steps:
-      - uses: googleapis/google-api-java-client-services/.github/workflows/generate.yaml@matrix-fix-2
-        with: 
-          # services: ${{fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour]}}
-          services: ${{fromJson(needs.batch.outputs.services).batches[0]}}
+    with: 
+      # services: ${{fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour]}}
+      services: ${{fromJson(needs.batch.outputs.services).batches[0]}}

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -36,7 +36,7 @@ jobs:
     needs: batch
     if: ${{fromJson(needs.batch.outputs.services).isEvenHour}}
     steps:
-      - uses: google-api-java-client-services/generate.yaml@matrix-fix-2
+      - uses: googleapis/google-api-java-client-services/generate.yaml@matrix-fix-2
         with: 
           services: fromJson(needs.batch.outputs.services).one
   generate_two:
@@ -44,6 +44,6 @@ jobs:
     needs: batch
     if: ${{!fromJson(needs.batch.outputs.services).isEvenHour}}
     steps:
-      - uses: google-api-java-client-services/generate.yaml@matrix-fix-2
+      - uses: googleapis/google-api-java-client-services/generate.yaml@matrix-fix-2
         with: 
           services: fromJson(needs.batch.outputs.services).two

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -1,7 +1,7 @@
 on:
   schedule:
     # daily at 12:30 am
-    - cron: '30 0,1 * * *'
+    - cron: '30 * * * *'
   workflow_dispatch:
 
 name: codegen
@@ -21,31 +21,21 @@ jobs:
             console.log('splitting service names list into batches')
             const services = ${{ needs.discovery.outputs.services }}
             const hour = new Date().getHours()
+            const MAX_BATCH_SIZE = 100
             const result = {
-              "one": [],
-              "two": [],
-              "isEvenHour": hour % 2 == 0,
+              batches: [],
+              hour: new Date().getHours(),
             };
-            for (let i = 0; i < services.length; i++) {
-              resultBatchKey = i % 2 ? "one" : "two";
-              result[resultBatchKey].push(services[i])
+            for (let i = 0; i < services.length; i += MAX_BATCH_SIZE) {
+              result.batches.push(services.slice(i, i + MAX_BATCH_SIZE))
             }
             return result
-  generate_one:
+  generate:
     runs-on: ubuntu-20.04
     needs: batch
-    if: ${{fromJson(needs.batch.outputs.services).isEvenHour}}
+    if: ${{!!fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour]}}
     steps:
-      - uses: actions/checkout@v3
-      - uses: googleapis/google-api-java-client-services/generate.yaml@matrix-fix-2
+      - uses: googleapis/google-api-java-client-services/.github/workflows/generate.yaml@matrix-fix-2
         with: 
-          services: fromJson(needs.batch.outputs.services).one
-  generate_two:
-    runs-on: ubuntu-20.04
-    needs: batch
-    if: ${{!fromJson(needs.batch.outputs.services).isEvenHour}}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: googleapis/google-api-java-client-services/generate.yaml@matrix-fix-2
-        with: 
-          services: fromJson(needs.batch.outputs.services).two
+          # services: ${{fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour]}}
+          services: ${{fromJson(needs.batch.outputs.services).batches[0]}}

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -7,7 +7,7 @@ on:
     inputs:
       services:
         required: true
-        type: array
+        type: string
 
 name: generate
 jobs:
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix: 
-        service: ${{fromJson(inputs.services)}}
+        service: ${{inputs.services}}
     steps:
       - run: echo generating ${{ matrix.service }}
       - uses: actions/checkout@v2

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix: 
-        service: ${{inputs.services}}
+        service: ${{fromJson(inputs.services)}}
     steps:
       - run: echo generating ${{ matrix.service }}
       - uses: actions/checkout@v2

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -33,18 +33,18 @@ jobs:
         with:
           python-version: 2.7.18
       - run: ./google-api-java-client-services/.github/workflows/generate.sh ${{ matrix.service }}
-      # - uses: googleapis/code-suggester@v2 # takes the changes from git directory
-      #   env:
-      #     ACCESS_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-      #   with:
-      #     command: pr
-      #     upstream_owner: ${{ github.repository_owner }}
-      #     upstream_repo: google-api-java-client-services
-      #     description: 'Generated in GitHub action: https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/workflows/codegen.yaml'
-      #     title: 'chore: regenerate ${{ matrix.service }} client'
-      #     message: 'chore: regenerate ${{ matrix.service }} client'
-      #     branch: regenerate-${{ matrix.service }}
-      #     git_dir: 'google-api-java-client-services/clients/google-api-services-${{ matrix.service }}'
-      #     primary: main
-      #     force: true
-      #     fork: true
+      - uses: googleapis/code-suggester@v2 # takes the changes from git directory
+        env:
+          ACCESS_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+        with:
+          command: pr
+          upstream_owner: ${{ github.repository_owner }}
+          upstream_repo: google-api-java-client-services
+          description: 'Generated in GitHub action: https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/workflows/codegen.yaml'
+          title: 'chore: regenerate ${{ matrix.service }} client'
+          message: 'chore: regenerate ${{ matrix.service }} client'
+          branch: regenerate-${{ matrix.service }}
+          git_dir: 'google-api-java-client-services/clients/google-api-services-${{ matrix.service }}'
+          primary: main
+          force: true
+          fork: true

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -1,0 +1,50 @@
+on:
+  schedule:
+    # daily at 12:30 am
+    - cron: '30 0,1 * * *'
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      services:
+        required: true
+        type: array
+
+name: generate
+jobs:
+  generate_one:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix: 
+        service: ${{fromJson(inputs.services)}}
+    steps:
+      - run: echo generating ${{ matrix.service }}
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+          path: google-api-java-client-services
+      - uses: actions/checkout@v2
+        with:
+          repository: googleapis/discovery-artifact-manager
+          fetch-depth: 1
+          path: discovery-artifact-manager
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 2.7.18
+      - run: ./google-api-java-client-services/.github/workflows/generate.sh ${{ matrix.service }}
+      # - uses: googleapis/code-suggester@v2 # takes the changes from git directory
+      #   env:
+      #     ACCESS_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+      #   with:
+      #     command: pr
+      #     upstream_owner: ${{ github.repository_owner }}
+      #     upstream_repo: google-api-java-client-services
+      #     description: 'Generated in GitHub action: https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/workflows/codegen.yaml'
+      #     title: 'chore: regenerate ${{ matrix.service }} client'
+      #     message: 'chore: regenerate ${{ matrix.service }} client'
+      #     branch: regenerate-${{ matrix.service }}
+      #     git_dir: 'google-api-java-client-services/clients/google-api-services-${{ matrix.service }}'
+      #     primary: main
+      #     force: true
+      #     fork: true

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -1,8 +1,9 @@
 on:
-  schedule:
-    # daily at 12:30 am
-    - cron: '30 0,1 * * *'
   workflow_dispatch:
+    inputs:
+      services:
+        required: true
+        type: string
   workflow_call:
     inputs:
       services:


### PR DESCRIPTION
Fixes [#16186](https://github.com/googleapis/google-api-java-client-services/issues/16186)
Also splits the services in batches of size 100. 
Each batch will be run at its own index based on the current hour. For example, if it's 01:30am then it will run `batches[1]`