### PR TITLE
fix: [do-not-merge] showcasing class de-duplication

### DIFF
--- a/clients/google-api-services-apigee/v1/2.0.0/com/google/api/services/apigee/v1/Apigee.java
+++ b/clients/google-api-services-apigee/v1/2.0.0/com/google/api/services/apigee/v1/Apigee.java
@@ -2880,20 +2880,20 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
        * Create a request for the method "apiproducts.attributes".
        *
        * This request holds the parameters needed by the apigee server.  After setting any optional
-       * parameters, call the {@link Attributes#execute()} method to invoke the remote operation.
+       * parameters, call the {@link AttributesRequest#execute()} method to invoke the remote operation.
        *
        * @param name Required. Name of the API product. Use the following structure in your request:
        *        `organizations/{org}/apiproducts/{apiproduct}`
        * @param content the {@link com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes}
        * @return the request
        */
-      public Attributes attributes(java.lang.String name, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes content) throws java.io.IOException {
-        Attributes result = new Attributes(name, content);
+      public AttributesRequest attributes(java.lang.String name, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes content) throws java.io.IOException {
+        AttributesRequest result = new AttributesRequest(name, content);
         initialize(result);
         return result;
       }
 
-      public class Attributes extends ApigeeRequest<com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes> {
+      public class AttributesRequest extends ApigeeRequest<com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes> {
 
         private static final String REST_PATH = "v1/{+name}/attributes";
 
@@ -2913,17 +2913,17 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
          * Create a request for the method "apiproducts.attributes".
          *
          * This request holds the parameters needed by the the apigee server.  After setting any optional
-         * parameters, call the {@link Attributes#execute()} method to invoke the remote operation. <p>
-         * {@link
-         * Attributes#initialize(com.google.api.client.googleapis.services.AbstractGoogleClientRequest)}
-         * must be called to initialize this instance immediately after invoking the constructor. </p>
+         * parameters, call the {@link AttributesRequest#execute()} method to invoke the remote operation.
+         * <p> {@link AttributesRequest#initialize(com.google.api.client.googleapis.services.AbstractGoogl
+         * eClientRequest)} must be called to initialize this instance immediately after invoking the
+         * constructor. </p>
          *
          * @param name Required. Name of the API product. Use the following structure in your request:
        *        `organizations/{org}/apiproducts/{apiproduct}`
          * @param content the {@link com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes}
          * @since 1.13
          */
-        protected Attributes(java.lang.String name, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes content) {
+        protected AttributesRequest(java.lang.String name, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes content) {
           super(Apigee.this, "POST", REST_PATH, content, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes.class);
           this.name = com.google.api.client.util.Preconditions.checkNotNull(name, "Required parameter name must be specified.");
           if (!getSuppressPatternChecks()) {
@@ -2934,58 +2934,58 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
         }
 
         @Override
-        public Attributes set$Xgafv(java.lang.String $Xgafv) {
-          return (Attributes) super.set$Xgafv($Xgafv);
+        public AttributesRequest set$Xgafv(java.lang.String $Xgafv) {
+          return (AttributesRequest) super.set$Xgafv($Xgafv);
         }
 
         @Override
-        public Attributes setAccessToken(java.lang.String accessToken) {
-          return (Attributes) super.setAccessToken(accessToken);
+        public AttributesRequest setAccessToken(java.lang.String accessToken) {
+          return (AttributesRequest) super.setAccessToken(accessToken);
         }
 
         @Override
-        public Attributes setAlt(java.lang.String alt) {
-          return (Attributes) super.setAlt(alt);
+        public AttributesRequest setAlt(java.lang.String alt) {
+          return (AttributesRequest) super.setAlt(alt);
         }
 
         @Override
-        public Attributes setCallback(java.lang.String callback) {
-          return (Attributes) super.setCallback(callback);
+        public AttributesRequest setCallback(java.lang.String callback) {
+          return (AttributesRequest) super.setCallback(callback);
         }
 
         @Override
-        public Attributes setFields(java.lang.String fields) {
-          return (Attributes) super.setFields(fields);
+        public AttributesRequest setFields(java.lang.String fields) {
+          return (AttributesRequest) super.setFields(fields);
         }
 
         @Override
-        public Attributes setKey(java.lang.String key) {
-          return (Attributes) super.setKey(key);
+        public AttributesRequest setKey(java.lang.String key) {
+          return (AttributesRequest) super.setKey(key);
         }
 
         @Override
-        public Attributes setOauthToken(java.lang.String oauthToken) {
-          return (Attributes) super.setOauthToken(oauthToken);
+        public AttributesRequest setOauthToken(java.lang.String oauthToken) {
+          return (AttributesRequest) super.setOauthToken(oauthToken);
         }
 
         @Override
-        public Attributes setPrettyPrint(java.lang.Boolean prettyPrint) {
-          return (Attributes) super.setPrettyPrint(prettyPrint);
+        public AttributesRequest setPrettyPrint(java.lang.Boolean prettyPrint) {
+          return (AttributesRequest) super.setPrettyPrint(prettyPrint);
         }
 
         @Override
-        public Attributes setQuotaUser(java.lang.String quotaUser) {
-          return (Attributes) super.setQuotaUser(quotaUser);
+        public AttributesRequest setQuotaUser(java.lang.String quotaUser) {
+          return (AttributesRequest) super.setQuotaUser(quotaUser);
         }
 
         @Override
-        public Attributes setUploadType(java.lang.String uploadType) {
-          return (Attributes) super.setUploadType(uploadType);
+        public AttributesRequest setUploadType(java.lang.String uploadType) {
+          return (AttributesRequest) super.setUploadType(uploadType);
         }
 
         @Override
-        public Attributes setUploadProtocol(java.lang.String uploadProtocol) {
-          return (Attributes) super.setUploadProtocol(uploadProtocol);
+        public AttributesRequest setUploadProtocol(java.lang.String uploadProtocol) {
+          return (AttributesRequest) super.setUploadProtocol(uploadProtocol);
         }
 
         /**
@@ -3006,7 +3006,7 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
          * Required. Name of the API product. Use the following structure in your request:
          * `organizations/{org}/apiproducts/{apiproduct}`
          */
-        public Attributes setName(java.lang.String name) {
+        public AttributesRequest setName(java.lang.String name) {
           if (!getSuppressPatternChecks()) {
             com.google.api.client.util.Preconditions.checkArgument(NAME_PATTERN.matcher(name).matches(),
                 "Parameter name must conform to the pattern " +
@@ -3017,8 +3017,8 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
         }
 
         @Override
-        public Attributes set(String parameterName, Object value) {
-          return (Attributes) super.set(parameterName, value);
+        public AttributesRequest set(String parameterName, Object value) {
+          return (AttributesRequest) super.set(parameterName, value);
         }
       }
       /**
@@ -9561,20 +9561,20 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
        * Create a request for the method "developers.attributes".
        *
        * This request holds the parameters needed by the apigee server.  After setting any optional
-       * parameters, call the {@link Attributes#execute()} method to invoke the remote operation.
+       * parameters, call the {@link AttributesRequest#execute()} method to invoke the remote operation.
        *
        * @param parent Required. Email address of the developer for which attributes are being updated. Use the following
        *        structure in your request: `organizations/{org}/developers/{developer_email}`
        * @param content the {@link com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes}
        * @return the request
        */
-      public Attributes attributes(java.lang.String parent, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes content) throws java.io.IOException {
-        Attributes result = new Attributes(parent, content);
+      public AttributesRequest attributes(java.lang.String parent, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes content) throws java.io.IOException {
+        AttributesRequest result = new AttributesRequest(parent, content);
         initialize(result);
         return result;
       }
 
-      public class Attributes extends ApigeeRequest<com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes> {
+      public class AttributesRequest extends ApigeeRequest<com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes> {
 
         private static final String REST_PATH = "v1/{+parent}/attributes";
 
@@ -9594,17 +9594,17 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
          * Create a request for the method "developers.attributes".
          *
          * This request holds the parameters needed by the the apigee server.  After setting any optional
-         * parameters, call the {@link Attributes#execute()} method to invoke the remote operation. <p>
-         * {@link
-         * Attributes#initialize(com.google.api.client.googleapis.services.AbstractGoogleClientRequest)}
-         * must be called to initialize this instance immediately after invoking the constructor. </p>
+         * parameters, call the {@link AttributesRequest#execute()} method to invoke the remote operation.
+         * <p> {@link AttributesRequest#initialize(com.google.api.client.googleapis.services.AbstractGoogl
+         * eClientRequest)} must be called to initialize this instance immediately after invoking the
+         * constructor. </p>
          *
          * @param parent Required. Email address of the developer for which attributes are being updated. Use the following
        *        structure in your request: `organizations/{org}/developers/{developer_email}`
          * @param content the {@link com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes}
          * @since 1.13
          */
-        protected Attributes(java.lang.String parent, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes content) {
+        protected AttributesRequest(java.lang.String parent, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes content) {
           super(Apigee.this, "POST", REST_PATH, content, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes.class);
           this.parent = com.google.api.client.util.Preconditions.checkNotNull(parent, "Required parameter parent must be specified.");
           if (!getSuppressPatternChecks()) {
@@ -9615,58 +9615,58 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
         }
 
         @Override
-        public Attributes set$Xgafv(java.lang.String $Xgafv) {
-          return (Attributes) super.set$Xgafv($Xgafv);
+        public AttributesRequest set$Xgafv(java.lang.String $Xgafv) {
+          return (AttributesRequest) super.set$Xgafv($Xgafv);
         }
 
         @Override
-        public Attributes setAccessToken(java.lang.String accessToken) {
-          return (Attributes) super.setAccessToken(accessToken);
+        public AttributesRequest setAccessToken(java.lang.String accessToken) {
+          return (AttributesRequest) super.setAccessToken(accessToken);
         }
 
         @Override
-        public Attributes setAlt(java.lang.String alt) {
-          return (Attributes) super.setAlt(alt);
+        public AttributesRequest setAlt(java.lang.String alt) {
+          return (AttributesRequest) super.setAlt(alt);
         }
 
         @Override
-        public Attributes setCallback(java.lang.String callback) {
-          return (Attributes) super.setCallback(callback);
+        public AttributesRequest setCallback(java.lang.String callback) {
+          return (AttributesRequest) super.setCallback(callback);
         }
 
         @Override
-        public Attributes setFields(java.lang.String fields) {
-          return (Attributes) super.setFields(fields);
+        public AttributesRequest setFields(java.lang.String fields) {
+          return (AttributesRequest) super.setFields(fields);
         }
 
         @Override
-        public Attributes setKey(java.lang.String key) {
-          return (Attributes) super.setKey(key);
+        public AttributesRequest setKey(java.lang.String key) {
+          return (AttributesRequest) super.setKey(key);
         }
 
         @Override
-        public Attributes setOauthToken(java.lang.String oauthToken) {
-          return (Attributes) super.setOauthToken(oauthToken);
+        public AttributesRequest setOauthToken(java.lang.String oauthToken) {
+          return (AttributesRequest) super.setOauthToken(oauthToken);
         }
 
         @Override
-        public Attributes setPrettyPrint(java.lang.Boolean prettyPrint) {
-          return (Attributes) super.setPrettyPrint(prettyPrint);
+        public AttributesRequest setPrettyPrint(java.lang.Boolean prettyPrint) {
+          return (AttributesRequest) super.setPrettyPrint(prettyPrint);
         }
 
         @Override
-        public Attributes setQuotaUser(java.lang.String quotaUser) {
-          return (Attributes) super.setQuotaUser(quotaUser);
+        public AttributesRequest setQuotaUser(java.lang.String quotaUser) {
+          return (AttributesRequest) super.setQuotaUser(quotaUser);
         }
 
         @Override
-        public Attributes setUploadType(java.lang.String uploadType) {
-          return (Attributes) super.setUploadType(uploadType);
+        public AttributesRequest setUploadType(java.lang.String uploadType) {
+          return (AttributesRequest) super.setUploadType(uploadType);
         }
 
         @Override
-        public Attributes setUploadProtocol(java.lang.String uploadProtocol) {
-          return (Attributes) super.setUploadProtocol(uploadProtocol);
+        public AttributesRequest setUploadProtocol(java.lang.String uploadProtocol) {
+          return (AttributesRequest) super.setUploadProtocol(uploadProtocol);
         }
 
         /**
@@ -9687,7 +9687,7 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
          * Required. Email address of the developer for which attributes are being updated. Use the
          * following structure in your request: `organizations/{org}/developers/{developer_email}`
          */
-        public Attributes setParent(java.lang.String parent) {
+        public AttributesRequest setParent(java.lang.String parent) {
           if (!getSuppressPatternChecks()) {
             com.google.api.client.util.Preconditions.checkArgument(PARENT_PATTERN.matcher(parent).matches(),
                 "Parameter parent must conform to the pattern " +
@@ -9698,8 +9698,8 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
         }
 
         @Override
-        public Attributes set(String parameterName, Object value) {
-          return (Attributes) super.set(parameterName, value);
+        public AttributesRequest set(String parameterName, Object value) {
+          return (AttributesRequest) super.set(parameterName, value);
         }
       }
       /**
@@ -11228,20 +11228,20 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
          * Create a request for the method "apps.attributes".
          *
          * This request holds the parameters needed by the apigee server.  After setting any optional
-         * parameters, call the {@link Attributes#execute()} method to invoke the remote operation.
+         * parameters, call the {@link AttributesRequest#execute()} method to invoke the remote operation.
          *
          * @param name Required. Name of the developer app. Use the following structure in your request:
          *        `organizations/{org}/developers/{developer_email}/apps/{app}`
          * @param content the {@link com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes}
          * @return the request
          */
-        public Attributes attributes(java.lang.String name, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes content) throws java.io.IOException {
-          Attributes result = new Attributes(name, content);
+        public AttributesRequest attributes(java.lang.String name, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes content) throws java.io.IOException {
+          AttributesRequest result = new AttributesRequest(name, content);
           initialize(result);
           return result;
         }
 
-        public class Attributes extends ApigeeRequest<com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes> {
+        public class AttributesRequest extends ApigeeRequest<com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes> {
 
           private static final String REST_PATH = "v1/{+name}/attributes";
 
@@ -11255,17 +11255,17 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
            * Create a request for the method "apps.attributes".
            *
            * This request holds the parameters needed by the the apigee server.  After setting any optional
-           * parameters, call the {@link Attributes#execute()} method to invoke the remote operation. <p>
-           * {@link
-           * Attributes#initialize(com.google.api.client.googleapis.services.AbstractGoogleClientRequest)}
-           * must be called to initialize this instance immediately after invoking the constructor. </p>
+           * parameters, call the {@link AttributesRequest#execute()} method to invoke the remote operation.
+           * <p> {@link AttributesRequest#initialize(com.google.api.client.googleapis.services.AbstractGoogl
+           * eClientRequest)} must be called to initialize this instance immediately after invoking the
+           * constructor. </p>
            *
            * @param name Required. Name of the developer app. Use the following structure in your request:
          *        `organizations/{org}/developers/{developer_email}/apps/{app}`
            * @param content the {@link com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes}
            * @since 1.13
            */
-          protected Attributes(java.lang.String name, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes content) {
+          protected AttributesRequest(java.lang.String name, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes content) {
             super(Apigee.this, "POST", REST_PATH, content, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1Attributes.class);
             this.name = com.google.api.client.util.Preconditions.checkNotNull(name, "Required parameter name must be specified.");
             if (!getSuppressPatternChecks()) {
@@ -11276,58 +11276,58 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
           }
 
           @Override
-          public Attributes set$Xgafv(java.lang.String $Xgafv) {
-            return (Attributes) super.set$Xgafv($Xgafv);
+          public AttributesRequest set$Xgafv(java.lang.String $Xgafv) {
+            return (AttributesRequest) super.set$Xgafv($Xgafv);
           }
 
           @Override
-          public Attributes setAccessToken(java.lang.String accessToken) {
-            return (Attributes) super.setAccessToken(accessToken);
+          public AttributesRequest setAccessToken(java.lang.String accessToken) {
+            return (AttributesRequest) super.setAccessToken(accessToken);
           }
 
           @Override
-          public Attributes setAlt(java.lang.String alt) {
-            return (Attributes) super.setAlt(alt);
+          public AttributesRequest setAlt(java.lang.String alt) {
+            return (AttributesRequest) super.setAlt(alt);
           }
 
           @Override
-          public Attributes setCallback(java.lang.String callback) {
-            return (Attributes) super.setCallback(callback);
+          public AttributesRequest setCallback(java.lang.String callback) {
+            return (AttributesRequest) super.setCallback(callback);
           }
 
           @Override
-          public Attributes setFields(java.lang.String fields) {
-            return (Attributes) super.setFields(fields);
+          public AttributesRequest setFields(java.lang.String fields) {
+            return (AttributesRequest) super.setFields(fields);
           }
 
           @Override
-          public Attributes setKey(java.lang.String key) {
-            return (Attributes) super.setKey(key);
+          public AttributesRequest setKey(java.lang.String key) {
+            return (AttributesRequest) super.setKey(key);
           }
 
           @Override
-          public Attributes setOauthToken(java.lang.String oauthToken) {
-            return (Attributes) super.setOauthToken(oauthToken);
+          public AttributesRequest setOauthToken(java.lang.String oauthToken) {
+            return (AttributesRequest) super.setOauthToken(oauthToken);
           }
 
           @Override
-          public Attributes setPrettyPrint(java.lang.Boolean prettyPrint) {
-            return (Attributes) super.setPrettyPrint(prettyPrint);
+          public AttributesRequest setPrettyPrint(java.lang.Boolean prettyPrint) {
+            return (AttributesRequest) super.setPrettyPrint(prettyPrint);
           }
 
           @Override
-          public Attributes setQuotaUser(java.lang.String quotaUser) {
-            return (Attributes) super.setQuotaUser(quotaUser);
+          public AttributesRequest setQuotaUser(java.lang.String quotaUser) {
+            return (AttributesRequest) super.setQuotaUser(quotaUser);
           }
 
           @Override
-          public Attributes setUploadType(java.lang.String uploadType) {
-            return (Attributes) super.setUploadType(uploadType);
+          public AttributesRequest setUploadType(java.lang.String uploadType) {
+            return (AttributesRequest) super.setUploadType(uploadType);
           }
 
           @Override
-          public Attributes setUploadProtocol(java.lang.String uploadProtocol) {
-            return (Attributes) super.setUploadProtocol(uploadProtocol);
+          public AttributesRequest setUploadProtocol(java.lang.String uploadProtocol) {
+            return (AttributesRequest) super.setUploadProtocol(uploadProtocol);
           }
 
           /**
@@ -11348,7 +11348,7 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
            * Required. Name of the developer app. Use the following structure in your request:
            * `organizations/{org}/developers/{developer_email}/apps/{app}`
            */
-          public Attributes setName(java.lang.String name) {
+          public AttributesRequest setName(java.lang.String name) {
             if (!getSuppressPatternChecks()) {
               com.google.api.client.util.Preconditions.checkArgument(NAME_PATTERN.matcher(name).matches(),
                   "Parameter name must conform to the pattern " +
@@ -11359,8 +11359,8 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
           }
 
           @Override
-          public Attributes set(String parameterName, Object value) {
-            return (Attributes) super.set(parameterName, value);
+          public AttributesRequest set(String parameterName, Object value) {
+            return (AttributesRequest) super.set(parameterName, value);
           }
         }
         /**
@@ -13099,20 +13099,20 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
            * Create a request for the method "keys.create".
            *
            * This request holds the parameters needed by the apigee server.  After setting any optional
-           * parameters, call the {@link Create#execute()} method to invoke the remote operation.
+           * parameters, call the {@link CreateRequest#execute()} method to invoke the remote operation.
            *
            * @param parent Parent of the developer app key. Use the following structure in your request:
            *        `organizations/{org}/developers/{developer_email}/apps`
            * @param content the {@link com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1DeveloperAppKey}
            * @return the request
            */
-          public Create create(java.lang.String parent, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1DeveloperAppKey content) throws java.io.IOException {
-            Create result = new Create(parent, content);
+          public CreateRequest create(java.lang.String parent, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1DeveloperAppKey content) throws java.io.IOException {
+            CreateRequest result = new CreateRequest(parent, content);
             initialize(result);
             return result;
           }
 
-          public class Create extends ApigeeRequest<com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1DeveloperAppKey> {
+          public class CreateRequest extends ApigeeRequest<com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1DeveloperAppKey> {
 
             private static final String REST_PATH = "v1/{+parent}/keys";
 
@@ -13133,16 +13133,17 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
              * Create a request for the method "keys.create".
              *
              * This request holds the parameters needed by the the apigee server.  After setting any optional
-             * parameters, call the {@link Create#execute()} method to invoke the remote operation. <p> {@link
-             * Create#initialize(com.google.api.client.googleapis.services.AbstractGoogleClientRequest)} must
-             * be called to initialize this instance immediately after invoking the constructor. </p>
+             * parameters, call the {@link CreateRequest#execute()} method to invoke the remote operation. <p>
+             * {@link CreateRequest#initialize(com.google.api.client.googleapis.services.AbstractGoogleClientR
+             * equest)} must be called to initialize this instance immediately after invoking the constructor.
+             * </p>
              *
              * @param parent Parent of the developer app key. Use the following structure in your request:
            *        `organizations/{org}/developers/{developer_email}/apps`
              * @param content the {@link com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1DeveloperAppKey}
              * @since 1.13
              */
-            protected Create(java.lang.String parent, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1DeveloperAppKey content) {
+            protected CreateRequest(java.lang.String parent, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1DeveloperAppKey content) {
               super(Apigee.this, "POST", REST_PATH, content, com.google.api.services.apigee.v1.model.GoogleCloudApigeeV1DeveloperAppKey.class);
               this.parent = com.google.api.client.util.Preconditions.checkNotNull(parent, "Required parameter parent must be specified.");
               if (!getSuppressPatternChecks()) {
@@ -13153,58 +13154,58 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
             }
 
             @Override
-            public Create set$Xgafv(java.lang.String $Xgafv) {
-              return (Create) super.set$Xgafv($Xgafv);
+            public CreateRequest set$Xgafv(java.lang.String $Xgafv) {
+              return (CreateRequest) super.set$Xgafv($Xgafv);
             }
 
             @Override
-            public Create setAccessToken(java.lang.String accessToken) {
-              return (Create) super.setAccessToken(accessToken);
+            public CreateRequest setAccessToken(java.lang.String accessToken) {
+              return (CreateRequest) super.setAccessToken(accessToken);
             }
 
             @Override
-            public Create setAlt(java.lang.String alt) {
-              return (Create) super.setAlt(alt);
+            public CreateRequest setAlt(java.lang.String alt) {
+              return (CreateRequest) super.setAlt(alt);
             }
 
             @Override
-            public Create setCallback(java.lang.String callback) {
-              return (Create) super.setCallback(callback);
+            public CreateRequest setCallback(java.lang.String callback) {
+              return (CreateRequest) super.setCallback(callback);
             }
 
             @Override
-            public Create setFields(java.lang.String fields) {
-              return (Create) super.setFields(fields);
+            public CreateRequest setFields(java.lang.String fields) {
+              return (CreateRequest) super.setFields(fields);
             }
 
             @Override
-            public Create setKey(java.lang.String key) {
-              return (Create) super.setKey(key);
+            public CreateRequest setKey(java.lang.String key) {
+              return (CreateRequest) super.setKey(key);
             }
 
             @Override
-            public Create setOauthToken(java.lang.String oauthToken) {
-              return (Create) super.setOauthToken(oauthToken);
+            public CreateRequest setOauthToken(java.lang.String oauthToken) {
+              return (CreateRequest) super.setOauthToken(oauthToken);
             }
 
             @Override
-            public Create setPrettyPrint(java.lang.Boolean prettyPrint) {
-              return (Create) super.setPrettyPrint(prettyPrint);
+            public CreateRequest setPrettyPrint(java.lang.Boolean prettyPrint) {
+              return (CreateRequest) super.setPrettyPrint(prettyPrint);
             }
 
             @Override
-            public Create setQuotaUser(java.lang.String quotaUser) {
-              return (Create) super.setQuotaUser(quotaUser);
+            public CreateRequest setQuotaUser(java.lang.String quotaUser) {
+              return (CreateRequest) super.setQuotaUser(quotaUser);
             }
 
             @Override
-            public Create setUploadType(java.lang.String uploadType) {
-              return (Create) super.setUploadType(uploadType);
+            public CreateRequest setUploadType(java.lang.String uploadType) {
+              return (CreateRequest) super.setUploadType(uploadType);
             }
 
             @Override
-            public Create setUploadProtocol(java.lang.String uploadProtocol) {
-              return (Create) super.setUploadProtocol(uploadProtocol);
+            public CreateRequest setUploadProtocol(java.lang.String uploadProtocol) {
+              return (CreateRequest) super.setUploadProtocol(uploadProtocol);
             }
 
             /**
@@ -13225,7 +13226,7 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
              * Parent of the developer app key. Use the following structure in your request:
              * `organizations/{org}/developers/{developer_email}/apps`
              */
-            public Create setParent(java.lang.String parent) {
+            public CreateRequest setParent(java.lang.String parent) {
               if (!getSuppressPatternChecks()) {
                 com.google.api.client.util.Preconditions.checkArgument(PARENT_PATTERN.matcher(parent).matches(),
                     "Parameter parent must conform to the pattern " +
@@ -13236,8 +13237,8 @@ public class Apigee extends com.google.api.client.googleapis.services.json.Abstr
             }
 
             @Override
-            public Create set(String parameterName, Object value) {
-              return (Create) super.set(parameterName, value);
+            public CreateRequest set(String parameterName, Object value) {
+              return (CreateRequest) super.set(parameterName, value);
             }
           }
           /**

--- a/clients/google-api-services-assuredworkloads/v1beta1/2.0.0/com/google/api/services/assuredworkloads/v1beta1/Assuredworkloads.java
+++ b/clients/google-api-services-assuredworkloads/v1beta1/2.0.0/com/google/api/services/assuredworkloads/v1beta1/Assuredworkloads.java
@@ -1561,64 +1561,64 @@ public class Assuredworkloads extends com.google.api.client.googleapis.services.
         }
 
         /**
-         * An accessor for creating requests from the Organizations collection.
+         * An accessor for creating requests from the ChildOrganizations collection.
          *
          * <p>The typical use is:</p>
          * <pre>
          *   {@code Assuredworkloads assuredworkloads = new Assuredworkloads(...);}
-         *   {@code Assuredworkloads.Organizations.List request = assuredworkloads.organizations().list(parameters ...)}
+         *   {@code Assuredworkloads.ChildOrganizations.List request = assuredworkloads.childOrganizations().list(parameters ...)}
          * </pre>
          *
          * @return the resource collection
          */
-        public Organizations organizations() {
-          return new Organizations();
+        public ChildOrganizations childOrganizations() {
+          return new ChildOrganizations();
         }
 
         /**
          * The "organizations" collection of methods.
          */
-        public class Organizations {
+        public class ChildOrganizations {
 
           /**
-           * An accessor for creating requests from the Locations collection.
+           * An accessor for creating requests from the ChildLocations collection.
            *
            * <p>The typical use is:</p>
            * <pre>
            *   {@code Assuredworkloads assuredworkloads = new Assuredworkloads(...);}
-           *   {@code Assuredworkloads.Locations.List request = assuredworkloads.locations().list(parameters ...)}
+           *   {@code Assuredworkloads.ChildLocations.List request = assuredworkloads.childLocations().list(parameters ...)}
            * </pre>
            *
            * @return the resource collection
            */
-          public Locations locations() {
-            return new Locations();
+          public ChildLocations childLocations() {
+            return new ChildLocations();
           }
 
           /**
            * The "locations" collection of methods.
            */
-          public class Locations {
+          public class ChildLocations {
 
             /**
-             * An accessor for creating requests from the Workloads collection.
+             * An accessor for creating requests from the ChildWorkloads collection.
              *
              * <p>The typical use is:</p>
              * <pre>
              *   {@code Assuredworkloads assuredworkloads = new Assuredworkloads(...);}
-             *   {@code Assuredworkloads.Workloads.List request = assuredworkloads.workloads().list(parameters ...)}
+             *   {@code Assuredworkloads.ChildWorkloads.List request = assuredworkloads.childWorkloads().list(parameters ...)}
              * </pre>
              *
              * @return the resource collection
              */
-            public Workloads workloads() {
-              return new Workloads();
+            public ChildWorkloads childWorkloads() {
+              return new ChildWorkloads();
             }
 
             /**
              * The "workloads" collection of methods.
              */
-            public class Workloads {
+            public class ChildWorkloads {
 
               /**
                * Analyzes a hypothetical move of a source project or project-based workload to a target

--- a/clients/google-api-services-bigtableadmin/v2/2.0.0/com/google/api/services/bigtableadmin/v2/BigtableAdmin.java
+++ b/clients/google-api-services-bigtableadmin/v2/2.0.0/com/google/api/services/bigtableadmin/v2/BigtableAdmin.java
@@ -589,24 +589,24 @@ public class BigtableAdmin extends com.google.api.client.googleapis.services.jso
     public class Projects {
 
       /**
-       * An accessor for creating requests from the Operations collection.
+       * An accessor for creating requests from the ChildOperations collection.
        *
        * <p>The typical use is:</p>
        * <pre>
        *   {@code BigtableAdmin bigtableadmin = new BigtableAdmin(...);}
-       *   {@code BigtableAdmin.Operations.List request = bigtableadmin.operations().list(parameters ...)}
+       *   {@code BigtableAdmin.ChildOperations.List request = bigtableadmin.childOperations().list(parameters ...)}
        * </pre>
        *
        * @return the resource collection
        */
-      public Operations operations() {
-        return new Operations();
+      public ChildOperations childOperations() {
+        return new ChildOperations();
       }
 
       /**
        * The "operations" collection of methods.
        */
-      public class Operations {
+      public class ChildOperations {
 
         /**
          * Lists operations that match the specified filter in the request. If the server doesn't support

--- a/clients/google-api-services-identitytoolkit/v1/2.0.0/com/google/api/services/identitytoolkit/v1/IdentityToolkit.java
+++ b/clients/google-api-services-identitytoolkit/v1/2.0.0/com/google/api/services/identitytoolkit/v1/IdentityToolkit.java
@@ -1897,7 +1897,8 @@ public class IdentityToolkit extends com.google.api.client.googleapis.services.j
      * Create a request for the method "projects.accounts".
      *
      * This request holds the parameters needed by the identitytoolkit server.  After setting any
-     * optional parameters, call the {@link Accounts#execute()} method to invoke the remote operation.
+     * optional parameters, call the {@link AccountsRequest#execute()} method to invoke the remote
+     * operation.
      *
      * @param targetProjectId The project ID of the project which the user should belong to. Specifying this field requires a
      *        Google OAuth 2.0 credential with the proper [permissions](https://cloud.google.com
@@ -1906,13 +1907,13 @@ public class IdentityToolkit extends com.google.api.client.googleapis.services.j
      * @param content the {@link com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpRequest}
      * @return the request
      */
-    public Accounts accounts(java.lang.String targetProjectId, com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpRequest content) throws java.io.IOException {
-      Accounts result = new Accounts(targetProjectId, content);
+    public AccountsRequest accounts(java.lang.String targetProjectId, com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpRequest content) throws java.io.IOException {
+      AccountsRequest result = new AccountsRequest(targetProjectId, content);
       initialize(result);
       return result;
     }
 
-    public class Accounts extends IdentityToolkitRequest<com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpResponse> {
+    public class AccountsRequest extends IdentityToolkitRequest<com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpResponse> {
 
       private static final String REST_PATH = "v1/projects/{+targetProjectId}/accounts";
 
@@ -1930,10 +1931,10 @@ public class IdentityToolkit extends com.google.api.client.googleapis.services.j
        * Create a request for the method "projects.accounts".
        *
        * This request holds the parameters needed by the the identitytoolkit server.  After setting any
-       * optional parameters, call the {@link Accounts#execute()} method to invoke the remote operation.
-       * <p> {@link
-       * Accounts#initialize(com.google.api.client.googleapis.services.AbstractGoogleClientRequest)}
-       * must be called to initialize this instance immediately after invoking the constructor. </p>
+       * optional parameters, call the {@link AccountsRequest#execute()} method to invoke the remote
+       * operation. <p> {@link AccountsRequest#initialize(com.google.api.client.googleapis.services.Abst
+       * ractGoogleClientRequest)} must be called to initialize this instance immediately after invoking
+       * the constructor. </p>
        *
        * @param targetProjectId The project ID of the project which the user should belong to. Specifying this field requires a
      *        Google OAuth 2.0 credential with the proper [permissions](https://cloud.google.com
@@ -1942,7 +1943,7 @@ public class IdentityToolkit extends com.google.api.client.googleapis.services.j
        * @param content the {@link com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpRequest}
        * @since 1.13
        */
-      protected Accounts(java.lang.String targetProjectId, com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpRequest content) {
+      protected AccountsRequest(java.lang.String targetProjectId, com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpRequest content) {
         super(IdentityToolkit.this, "POST", REST_PATH, content, com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpResponse.class);
         this.targetProjectId = com.google.api.client.util.Preconditions.checkNotNull(targetProjectId, "Required parameter targetProjectId must be specified.");
         if (!getSuppressPatternChecks()) {
@@ -1953,58 +1954,58 @@ public class IdentityToolkit extends com.google.api.client.googleapis.services.j
       }
 
       @Override
-      public Accounts set$Xgafv(java.lang.String $Xgafv) {
-        return (Accounts) super.set$Xgafv($Xgafv);
+      public AccountsRequest set$Xgafv(java.lang.String $Xgafv) {
+        return (AccountsRequest) super.set$Xgafv($Xgafv);
       }
 
       @Override
-      public Accounts setAccessToken(java.lang.String accessToken) {
-        return (Accounts) super.setAccessToken(accessToken);
+      public AccountsRequest setAccessToken(java.lang.String accessToken) {
+        return (AccountsRequest) super.setAccessToken(accessToken);
       }
 
       @Override
-      public Accounts setAlt(java.lang.String alt) {
-        return (Accounts) super.setAlt(alt);
+      public AccountsRequest setAlt(java.lang.String alt) {
+        return (AccountsRequest) super.setAlt(alt);
       }
 
       @Override
-      public Accounts setCallback(java.lang.String callback) {
-        return (Accounts) super.setCallback(callback);
+      public AccountsRequest setCallback(java.lang.String callback) {
+        return (AccountsRequest) super.setCallback(callback);
       }
 
       @Override
-      public Accounts setFields(java.lang.String fields) {
-        return (Accounts) super.setFields(fields);
+      public AccountsRequest setFields(java.lang.String fields) {
+        return (AccountsRequest) super.setFields(fields);
       }
 
       @Override
-      public Accounts setKey(java.lang.String key) {
-        return (Accounts) super.setKey(key);
+      public AccountsRequest setKey(java.lang.String key) {
+        return (AccountsRequest) super.setKey(key);
       }
 
       @Override
-      public Accounts setOauthToken(java.lang.String oauthToken) {
-        return (Accounts) super.setOauthToken(oauthToken);
+      public AccountsRequest setOauthToken(java.lang.String oauthToken) {
+        return (AccountsRequest) super.setOauthToken(oauthToken);
       }
 
       @Override
-      public Accounts setPrettyPrint(java.lang.Boolean prettyPrint) {
-        return (Accounts) super.setPrettyPrint(prettyPrint);
+      public AccountsRequest setPrettyPrint(java.lang.Boolean prettyPrint) {
+        return (AccountsRequest) super.setPrettyPrint(prettyPrint);
       }
 
       @Override
-      public Accounts setQuotaUser(java.lang.String quotaUser) {
-        return (Accounts) super.setQuotaUser(quotaUser);
+      public AccountsRequest setQuotaUser(java.lang.String quotaUser) {
+        return (AccountsRequest) super.setQuotaUser(quotaUser);
       }
 
       @Override
-      public Accounts setUploadType(java.lang.String uploadType) {
-        return (Accounts) super.setUploadType(uploadType);
+      public AccountsRequest setUploadType(java.lang.String uploadType) {
+        return (AccountsRequest) super.setUploadType(uploadType);
       }
 
       @Override
-      public Accounts setUploadProtocol(java.lang.String uploadProtocol) {
-        return (Accounts) super.setUploadProtocol(uploadProtocol);
+      public AccountsRequest setUploadProtocol(java.lang.String uploadProtocol) {
+        return (AccountsRequest) super.setUploadProtocol(uploadProtocol);
       }
 
       /**
@@ -2033,7 +2034,7 @@ public class IdentityToolkit extends com.google.api.client.googleapis.services.j
        * not set, the target project is inferred from the scope associated to the Bearer access
        * token.
        */
-      public Accounts setTargetProjectId(java.lang.String targetProjectId) {
+      public AccountsRequest setTargetProjectId(java.lang.String targetProjectId) {
         if (!getSuppressPatternChecks()) {
           com.google.api.client.util.Preconditions.checkArgument(TARGET_PROJECT_ID_PATTERN.matcher(targetProjectId).matches(),
               "Parameter targetProjectId must conform to the pattern " +
@@ -2044,8 +2045,8 @@ public class IdentityToolkit extends com.google.api.client.googleapis.services.j
       }
 
       @Override
-      public Accounts set(String parameterName, Object value) {
-        return (Accounts) super.set(parameterName, value);
+      public AccountsRequest set(String parameterName, Object value) {
+        return (AccountsRequest) super.set(parameterName, value);
       }
     }
     /**
@@ -3614,7 +3615,8 @@ public class IdentityToolkit extends com.google.api.client.googleapis.services.j
        * Create a request for the method "tenants.accounts".
        *
        * This request holds the parameters needed by the identitytoolkit server.  After setting any
-       * optional parameters, call the {@link Accounts#execute()} method to invoke the remote operation.
+       * optional parameters, call the {@link AccountsRequest#execute()} method to invoke the remote
+       * operation.
        *
        * @param targetProjectId The project ID of the project which the user should belong to. Specifying this field requires a
        *        Google OAuth 2.0 credential with the proper [permissions](https://cloud.google.com
@@ -3625,13 +3627,13 @@ public class IdentityToolkit extends com.google.api.client.googleapis.services.j
        * @param content the {@link com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpRequest}
        * @return the request
        */
-      public Accounts accounts(java.lang.String targetProjectId, java.lang.String tenantId, com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpRequest content) throws java.io.IOException {
-        Accounts result = new Accounts(targetProjectId, tenantId, content);
+      public AccountsRequest accounts(java.lang.String targetProjectId, java.lang.String tenantId, com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpRequest content) throws java.io.IOException {
+        AccountsRequest result = new AccountsRequest(targetProjectId, tenantId, content);
         initialize(result);
         return result;
       }
 
-      public class Accounts extends IdentityToolkitRequest<com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpResponse> {
+      public class AccountsRequest extends IdentityToolkitRequest<com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpResponse> {
 
         private static final String REST_PATH = "v1/projects/{+targetProjectId}/tenants/{+tenantId}/accounts";
 
@@ -3652,10 +3654,10 @@ public class IdentityToolkit extends com.google.api.client.googleapis.services.j
          * Create a request for the method "tenants.accounts".
          *
          * This request holds the parameters needed by the the identitytoolkit server.  After setting any
-         * optional parameters, call the {@link Accounts#execute()} method to invoke the remote operation.
-         * <p> {@link
-         * Accounts#initialize(com.google.api.client.googleapis.services.AbstractGoogleClientRequest)}
-         * must be called to initialize this instance immediately after invoking the constructor. </p>
+         * optional parameters, call the {@link AccountsRequest#execute()} method to invoke the remote
+         * operation. <p> {@link AccountsRequest#initialize(com.google.api.client.googleapis.services.Abst
+         * ractGoogleClientRequest)} must be called to initialize this instance immediately after invoking
+         * the constructor. </p>
          *
          * @param targetProjectId The project ID of the project which the user should belong to. Specifying this field requires a
        *        Google OAuth 2.0 credential with the proper [permissions](https://cloud.google.com
@@ -3666,7 +3668,7 @@ public class IdentityToolkit extends com.google.api.client.googleapis.services.j
          * @param content the {@link com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpRequest}
          * @since 1.13
          */
-        protected Accounts(java.lang.String targetProjectId, java.lang.String tenantId, com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpRequest content) {
+        protected AccountsRequest(java.lang.String targetProjectId, java.lang.String tenantId, com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpRequest content) {
           super(IdentityToolkit.this, "POST", REST_PATH, content, com.google.api.services.identitytoolkit.v1.model.GoogleCloudIdentitytoolkitV1SignUpResponse.class);
           this.targetProjectId = com.google.api.client.util.Preconditions.checkNotNull(targetProjectId, "Required parameter targetProjectId must be specified.");
           if (!getSuppressPatternChecks()) {
@@ -3683,58 +3685,58 @@ public class IdentityToolkit extends com.google.api.client.googleapis.services.j
         }
 
         @Override
-        public Accounts set$Xgafv(java.lang.String $Xgafv) {
-          return (Accounts) super.set$Xgafv($Xgafv);
+        public AccountsRequest set$Xgafv(java.lang.String $Xgafv) {
+          return (AccountsRequest) super.set$Xgafv($Xgafv);
         }
 
         @Override
-        public Accounts setAccessToken(java.lang.String accessToken) {
-          return (Accounts) super.setAccessToken(accessToken);
+        public AccountsRequest setAccessToken(java.lang.String accessToken) {
+          return (AccountsRequest) super.setAccessToken(accessToken);
         }
 
         @Override
-        public Accounts setAlt(java.lang.String alt) {
-          return (Accounts) super.setAlt(alt);
+        public AccountsRequest setAlt(java.lang.String alt) {
+          return (AccountsRequest) super.setAlt(alt);
         }
 
         @Override
-        public Accounts setCallback(java.lang.String callback) {
-          return (Accounts) super.setCallback(callback);
+        public AccountsRequest setCallback(java.lang.String callback) {
+          return (AccountsRequest) super.setCallback(callback);
         }
 
         @Override
-        public Accounts setFields(java.lang.String fields) {
-          return (Accounts) super.setFields(fields);
+        public AccountsRequest setFields(java.lang.String fields) {
+          return (AccountsRequest) super.setFields(fields);
         }
 
         @Override
-        public Accounts setKey(java.lang.String key) {
-          return (Accounts) super.setKey(key);
+        public AccountsRequest setKey(java.lang.String key) {
+          return (AccountsRequest) super.setKey(key);
         }
 
         @Override
-        public Accounts setOauthToken(java.lang.String oauthToken) {
-          return (Accounts) super.setOauthToken(oauthToken);
+        public AccountsRequest setOauthToken(java.lang.String oauthToken) {
+          return (AccountsRequest) super.setOauthToken(oauthToken);
         }
 
         @Override
-        public Accounts setPrettyPrint(java.lang.Boolean prettyPrint) {
-          return (Accounts) super.setPrettyPrint(prettyPrint);
+        public AccountsRequest setPrettyPrint(java.lang.Boolean prettyPrint) {
+          return (AccountsRequest) super.setPrettyPrint(prettyPrint);
         }
 
         @Override
-        public Accounts setQuotaUser(java.lang.String quotaUser) {
-          return (Accounts) super.setQuotaUser(quotaUser);
+        public AccountsRequest setQuotaUser(java.lang.String quotaUser) {
+          return (AccountsRequest) super.setQuotaUser(quotaUser);
         }
 
         @Override
-        public Accounts setUploadType(java.lang.String uploadType) {
-          return (Accounts) super.setUploadType(uploadType);
+        public AccountsRequest setUploadType(java.lang.String uploadType) {
+          return (AccountsRequest) super.setUploadType(uploadType);
         }
 
         @Override
-        public Accounts setUploadProtocol(java.lang.String uploadProtocol) {
-          return (Accounts) super.setUploadProtocol(uploadProtocol);
+        public AccountsRequest setUploadProtocol(java.lang.String uploadProtocol) {
+          return (AccountsRequest) super.setUploadProtocol(uploadProtocol);
         }
 
         /**
@@ -3763,7 +3765,7 @@ public class IdentityToolkit extends com.google.api.client.googleapis.services.j
          * not set, the target project is inferred from the scope associated to the Bearer access
          * token.
          */
-        public Accounts setTargetProjectId(java.lang.String targetProjectId) {
+        public AccountsRequest setTargetProjectId(java.lang.String targetProjectId) {
           if (!getSuppressPatternChecks()) {
             com.google.api.client.util.Preconditions.checkArgument(TARGET_PROJECT_ID_PATTERN.matcher(targetProjectId).matches(),
                 "Parameter targetProjectId must conform to the pattern " +
@@ -3791,7 +3793,7 @@ public class IdentityToolkit extends com.google.api.client.googleapis.services.j
          * The ID of the Identity Platform tenant to create a user under. If not set, the user will
          * be created under the default Identity Platform project.
          */
-        public Accounts setTenantId(java.lang.String tenantId) {
+        public AccountsRequest setTenantId(java.lang.String tenantId) {
           if (!getSuppressPatternChecks()) {
             com.google.api.client.util.Preconditions.checkArgument(TENANT_ID_PATTERN.matcher(tenantId).matches(),
                 "Parameter tenantId must conform to the pattern " +
@@ -3802,8 +3804,8 @@ public class IdentityToolkit extends com.google.api.client.googleapis.services.j
         }
 
         @Override
-        public Accounts set(String parameterName, Object value) {
-          return (Accounts) super.set(parameterName, value);
+        public AccountsRequest set(String parameterName, Object value) {
+          return (AccountsRequest) super.set(parameterName, value);
         }
       }
       /**

--- a/clients/google-api-services-monitoring/v1/2.0.0/com/google/api/services/monitoring/v1/Monitoring.java
+++ b/clients/google-api-services-monitoring/v1/2.0.0/com/google/api/services/monitoring/v1/Monitoring.java
@@ -1897,7 +1897,7 @@ public class Monitoring extends com.google.api.client.googleapis.services.json.A
              * Create a request for the method "v1.labels".
              *
              * This request holds the parameters needed by the monitoring server.  After setting any optional
-             * parameters, call the {@link Labels#execute()} method to invoke the remote operation.
+             * parameters, call the {@link LabelsRequest#execute()} method to invoke the remote operation.
              *
              * @param name The workspace on which to execute the request. It is not part of the open source API but used as a
              *        request path prefix to distinguish different virtual Prometheus instances of Google
@@ -1906,13 +1906,13 @@ public class Monitoring extends com.google.api.client.googleapis.services.json.A
              * @param content the {@link com.google.api.services.monitoring.v1.model.ListLabelsRequest}
              * @return the request
              */
-            public Labels labels(java.lang.String name, java.lang.String location, com.google.api.services.monitoring.v1.model.ListLabelsRequest content) throws java.io.IOException {
-              Labels result = new Labels(name, location, content);
+            public LabelsRequest labels(java.lang.String name, java.lang.String location, com.google.api.services.monitoring.v1.model.ListLabelsRequest content) throws java.io.IOException {
+              LabelsRequest result = new LabelsRequest(name, location, content);
               initialize(result);
               return result;
             }
 
-            public class Labels extends MonitoringRequest<com.google.api.services.monitoring.v1.model.HttpBody> {
+            public class LabelsRequest extends MonitoringRequest<com.google.api.services.monitoring.v1.model.HttpBody> {
 
               private static final String REST_PATH = "v1/{+name}/location/{location}/prometheus/api/v1/labels";
 
@@ -1925,10 +1925,10 @@ public class Monitoring extends com.google.api.client.googleapis.services.json.A
                * Create a request for the method "v1.labels".
                *
                * This request holds the parameters needed by the the monitoring server.  After setting any
-               * optional parameters, call the {@link Labels#execute()} method to invoke the remote operation.
-               * <p> {@link
-               * Labels#initialize(com.google.api.client.googleapis.services.AbstractGoogleClientRequest)} must
-               * be called to initialize this instance immediately after invoking the constructor. </p>
+               * optional parameters, call the {@link LabelsRequest#execute()} method to invoke the remote
+               * operation. <p> {@link LabelsRequest#initialize(com.google.api.client.googleapis.services.Abstra
+               * ctGoogleClientRequest)} must be called to initialize this instance immediately after invoking
+               * the constructor. </p>
                *
                * @param name The workspace on which to execute the request. It is not part of the open source API but used as a
              *        request path prefix to distinguish different virtual Prometheus instances of Google
@@ -1937,7 +1937,7 @@ public class Monitoring extends com.google.api.client.googleapis.services.json.A
                * @param content the {@link com.google.api.services.monitoring.v1.model.ListLabelsRequest}
                * @since 1.13
                */
-              protected Labels(java.lang.String name, java.lang.String location, com.google.api.services.monitoring.v1.model.ListLabelsRequest content) {
+              protected LabelsRequest(java.lang.String name, java.lang.String location, com.google.api.services.monitoring.v1.model.ListLabelsRequest content) {
                 super(Monitoring.this, "POST", REST_PATH, content, com.google.api.services.monitoring.v1.model.HttpBody.class);
                 this.name = com.google.api.client.util.Preconditions.checkNotNull(name, "Required parameter name must be specified.");
                 if (!getSuppressPatternChecks()) {
@@ -1949,58 +1949,58 @@ public class Monitoring extends com.google.api.client.googleapis.services.json.A
               }
 
               @Override
-              public Labels set$Xgafv(java.lang.String $Xgafv) {
-                return (Labels) super.set$Xgafv($Xgafv);
+              public LabelsRequest set$Xgafv(java.lang.String $Xgafv) {
+                return (LabelsRequest) super.set$Xgafv($Xgafv);
               }
 
               @Override
-              public Labels setAccessToken(java.lang.String accessToken) {
-                return (Labels) super.setAccessToken(accessToken);
+              public LabelsRequest setAccessToken(java.lang.String accessToken) {
+                return (LabelsRequest) super.setAccessToken(accessToken);
               }
 
               @Override
-              public Labels setAlt(java.lang.String alt) {
-                return (Labels) super.setAlt(alt);
+              public LabelsRequest setAlt(java.lang.String alt) {
+                return (LabelsRequest) super.setAlt(alt);
               }
 
               @Override
-              public Labels setCallback(java.lang.String callback) {
-                return (Labels) super.setCallback(callback);
+              public LabelsRequest setCallback(java.lang.String callback) {
+                return (LabelsRequest) super.setCallback(callback);
               }
 
               @Override
-              public Labels setFields(java.lang.String fields) {
-                return (Labels) super.setFields(fields);
+              public LabelsRequest setFields(java.lang.String fields) {
+                return (LabelsRequest) super.setFields(fields);
               }
 
               @Override
-              public Labels setKey(java.lang.String key) {
-                return (Labels) super.setKey(key);
+              public LabelsRequest setKey(java.lang.String key) {
+                return (LabelsRequest) super.setKey(key);
               }
 
               @Override
-              public Labels setOauthToken(java.lang.String oauthToken) {
-                return (Labels) super.setOauthToken(oauthToken);
+              public LabelsRequest setOauthToken(java.lang.String oauthToken) {
+                return (LabelsRequest) super.setOauthToken(oauthToken);
               }
 
               @Override
-              public Labels setPrettyPrint(java.lang.Boolean prettyPrint) {
-                return (Labels) super.setPrettyPrint(prettyPrint);
+              public LabelsRequest setPrettyPrint(java.lang.Boolean prettyPrint) {
+                return (LabelsRequest) super.setPrettyPrint(prettyPrint);
               }
 
               @Override
-              public Labels setQuotaUser(java.lang.String quotaUser) {
-                return (Labels) super.setQuotaUser(quotaUser);
+              public LabelsRequest setQuotaUser(java.lang.String quotaUser) {
+                return (LabelsRequest) super.setQuotaUser(quotaUser);
               }
 
               @Override
-              public Labels setUploadType(java.lang.String uploadType) {
-                return (Labels) super.setUploadType(uploadType);
+              public LabelsRequest setUploadType(java.lang.String uploadType) {
+                return (LabelsRequest) super.setUploadType(uploadType);
               }
 
               @Override
-              public Labels setUploadProtocol(java.lang.String uploadProtocol) {
-                return (Labels) super.setUploadProtocol(uploadProtocol);
+              public LabelsRequest setUploadProtocol(java.lang.String uploadProtocol) {
+                return (LabelsRequest) super.setUploadProtocol(uploadProtocol);
               }
 
               /**
@@ -2026,7 +2026,7 @@ public class Monitoring extends com.google.api.client.googleapis.services.json.A
                * instances of Google Prometheus Engine. The format is:
                * projects/PROJECT_ID_OR_NUMBER.
                */
-              public Labels setName(java.lang.String name) {
+              public LabelsRequest setName(java.lang.String name) {
                 if (!getSuppressPatternChecks()) {
                   com.google.api.client.util.Preconditions.checkArgument(NAME_PATTERN.matcher(name).matches(),
                       "Parameter name must conform to the pattern " +
@@ -2047,14 +2047,14 @@ public class Monitoring extends com.google.api.client.googleapis.services.json.A
               }
 
               /** Location of the resource information. Has to be "global" now. */
-              public Labels setLocation(java.lang.String location) {
+              public LabelsRequest setLocation(java.lang.String location) {
                 this.location = location;
                 return this;
               }
 
               @Override
-              public Labels set(String parameterName, Object value) {
-                return (Labels) super.set(parameterName, value);
+              public LabelsRequest set(String parameterName, Object value) {
+                return (LabelsRequest) super.set(parameterName, value);
               }
             }
             /**

--- a/clients/google-api-services-prod_tt_sasportal/v1alpha1/2.0.0/com/google/api/services/prod_tt_sasportal/v1alpha1/SASPortalTesting.java
+++ b/clients/google-api-services-prod_tt_sasportal/v1alpha1/2.0.0/com/google/api/services/prod_tt_sasportal/v1alpha1/SASPortalTesting.java
@@ -5145,24 +5145,24 @@ public class SASPortalTesting extends com.google.api.client.googleapis.services.
 
       }
       /**
-       * An accessor for creating requests from the Nodes collection.
+       * An accessor for creating requests from the ChildNodes collection.
        *
        * <p>The typical use is:</p>
        * <pre>
        *   {@code SASPortalTesting prod_tt_sasportal = new SASPortalTesting(...);}
-       *   {@code SASPortalTesting.Nodes.List request = prod_tt_sasportal.nodes().list(parameters ...)}
+       *   {@code SASPortalTesting.ChildNodes.List request = prod_tt_sasportal.childNodes().list(parameters ...)}
        * </pre>
        *
        * @return the resource collection
        */
-      public Nodes nodes() {
-        return new Nodes();
+      public ChildNodes childNodes() {
+        return new ChildNodes();
       }
 
       /**
        * The "nodes" collection of methods.
        */
-      public class Nodes {
+      public class ChildNodes {
 
         /**
          * Creates a new node.
@@ -9451,24 +9451,24 @@ public class SASPortalTesting extends com.google.api.client.googleapis.services.
 
     }
     /**
-     * An accessor for creating requests from the Nodes collection.
+     * An accessor for creating requests from the ChildNodes collection.
      *
      * <p>The typical use is:</p>
      * <pre>
      *   {@code SASPortalTesting prod_tt_sasportal = new SASPortalTesting(...);}
-     *   {@code SASPortalTesting.Nodes.List request = prod_tt_sasportal.nodes().list(parameters ...)}
+     *   {@code SASPortalTesting.ChildNodes.List request = prod_tt_sasportal.childNodes().list(parameters ...)}
      * </pre>
      *
      * @return the resource collection
      */
-    public Nodes nodes() {
-      return new Nodes();
+    public ChildNodes childNodes() {
+      return new ChildNodes();
     }
 
     /**
      * The "nodes" collection of methods.
      */
-    public class Nodes {
+    public class ChildNodes {
 
       /**
        * Creates a new node.
@@ -11204,24 +11204,24 @@ public class SASPortalTesting extends com.google.api.client.googleapis.services.
 
       }
       /**
-       * An accessor for creating requests from the Nodes collection.
+       * An accessor for creating requests from the GrandChildNodes collection.
        *
        * <p>The typical use is:</p>
        * <pre>
        *   {@code SASPortalTesting prod_tt_sasportal = new SASPortalTesting(...);}
-       *   {@code SASPortalTesting.Nodes.List request = prod_tt_sasportal.nodes().list(parameters ...)}
+       *   {@code SASPortalTesting.GrandChildNodes.List request = prod_tt_sasportal.grandChildNodes().list(parameters ...)}
        * </pre>
        *
        * @return the resource collection
        */
-      public Nodes nodes() {
-        return new Nodes();
+      public GrandChildNodes grandChildNodes() {
+        return new GrandChildNodes();
       }
 
       /**
        * The "nodes" collection of methods.
        */
-      public class Nodes {
+      public class GrandChildNodes {
 
         /**
          * Creates a new node.

--- a/clients/google-api-services-sasportal/v1alpha1/2.0.0/com/google/api/services/sasportal/v1alpha1/Sasportal.java
+++ b/clients/google-api-services-sasportal/v1alpha1/2.0.0/com/google/api/services/sasportal/v1alpha1/Sasportal.java
@@ -5126,24 +5126,24 @@ public class Sasportal extends com.google.api.client.googleapis.services.json.Ab
 
       }
       /**
-       * An accessor for creating requests from the Nodes collection.
+       * An accessor for creating requests from the ChildNodes collection.
        *
        * <p>The typical use is:</p>
        * <pre>
        *   {@code Sasportal sasportal = new Sasportal(...);}
-       *   {@code Sasportal.Nodes.List request = sasportal.nodes().list(parameters ...)}
+       *   {@code Sasportal.ChildNodes.List request = sasportal.childNodes().list(parameters ...)}
        * </pre>
        *
        * @return the resource collection
        */
-      public Nodes nodes() {
-        return new Nodes();
+      public ChildNodes childNodes() {
+        return new ChildNodes();
       }
 
       /**
        * The "nodes" collection of methods.
        */
-      public class Nodes {
+      public class ChildNodes {
 
         /**
          * Creates a new node.
@@ -9415,24 +9415,24 @@ public class Sasportal extends com.google.api.client.googleapis.services.json.Ab
 
     }
     /**
-     * An accessor for creating requests from the Nodes collection.
+     * An accessor for creating requests from the ChildNodes collection.
      *
      * <p>The typical use is:</p>
      * <pre>
      *   {@code Sasportal sasportal = new Sasportal(...);}
-     *   {@code Sasportal.Nodes.List request = sasportal.nodes().list(parameters ...)}
+     *   {@code Sasportal.ChildNodes.List request = sasportal.childNodes().list(parameters ...)}
      * </pre>
      *
      * @return the resource collection
      */
-    public Nodes nodes() {
-      return new Nodes();
+    public ChildNodes childNodes() {
+      return new ChildNodes();
     }
 
     /**
      * The "nodes" collection of methods.
      */
-    public class Nodes {
+    public class ChildNodes {
 
       /**
        * Creates a new node.
@@ -11162,24 +11162,24 @@ public class Sasportal extends com.google.api.client.googleapis.services.json.Ab
 
       }
       /**
-       * An accessor for creating requests from the Nodes collection.
+       * An accessor for creating requests from the GrandChildNodes collection.
        *
        * <p>The typical use is:</p>
        * <pre>
        *   {@code Sasportal sasportal = new Sasportal(...);}
-       *   {@code Sasportal.Nodes.List request = sasportal.nodes().list(parameters ...)}
+       *   {@code Sasportal.GrandChildNodes.List request = sasportal.grandChildNodes().list(parameters ...)}
        * </pre>
        *
        * @return the resource collection
        */
-      public Nodes nodes() {
-        return new Nodes();
+      public GrandChildNodes grandChildNodes() {
+        return new GrandChildNodes();
       }
 
       /**
        * The "nodes" collection of methods.
        */
-      public class Nodes {
+      public class GrandChildNodes {
 
         /**
          * Creates a new node.

--- a/clients/google-api-services-videointelligence/v1/2.0.0/com/google/api/services/videointelligence/v1/CloudVideoIntelligence.java
+++ b/clients/google-api-services-videointelligence/v1/2.0.0/com/google/api/services/videointelligence/v1/CloudVideoIntelligence.java
@@ -194,24 +194,24 @@ public class CloudVideoIntelligence extends com.google.api.client.googleapis.ser
       public class Locations {
 
         /**
-         * An accessor for creating requests from the Operations collection.
+         * An accessor for creating requests from the ChildOperations collection.
          *
          * <p>The typical use is:</p>
          * <pre>
          *   {@code CloudVideoIntelligence videointelligence = new CloudVideoIntelligence(...);}
-         *   {@code CloudVideoIntelligence.Operations.List request = videointelligence.operations().list(parameters ...)}
+         *   {@code CloudVideoIntelligence.ChildOperations.List request = videointelligence.childOperations().list(parameters ...)}
          * </pre>
          *
          * @return the resource collection
          */
-        public Operations operations() {
-          return new Operations();
+        public ChildOperations childOperations() {
+          return new ChildOperations();
         }
 
         /**
          * The "operations" collection of methods.
          */
-        public class Operations {
+        public class ChildOperations {
 
           /**
            * Starts asynchronous cancellation on a long-running operation. The server makes a best effort to

--- a/generator/src/googleapis/codegen/api.py
+++ b/generator/src/googleapis/codegen/api.py
@@ -35,7 +35,6 @@ import logging
 import operator
 import urlparse
 
-
 from googleapis.codegen import data_types
 from googleapis.codegen import template_objects
 from googleapis.codegen import utilities
@@ -330,7 +329,7 @@ class Api(template_objects.CodeObject):
       self._api.SetTemplateValue('rootUrl', '%s://%s/' % (scheme, service_host))
     if service_path is None:
       self._api.SetTemplateValue('servicePath', base_path[1:])
-    
+
     # TODO(sijunliu): remove this once mtlsRootUrl is available in all services.
     if not self.values.get('mtlsRootUrl') and root_url:
       mtls_root_url = root_url.replace('googleapis.com', 'mtls.googleapis.com')
@@ -353,7 +352,7 @@ class Api(template_objects.CodeObject):
     return [m for m in self.ModelClasses() if not m.parent]
 
   def DataTypeFromJson(self, type_dict, default_name, parent=None,
-                       wire_name=None):
+      wire_name=None):
     """Returns a schema object represented by a JSON Schema dictionary.
 
     Evaluate a JSON schema dictionary and return an appropriate schema object.
@@ -557,14 +556,10 @@ class Resource(template_objects.CodeObject):
     """
     super(Resource, self).__init__(def_dict, api, parent=parent, wire_name=name)
     self.ValidateName(name)
-    class_name = api.ToClassName(name, self, element_type='resource')
+    raw_class_name = api.ToClassName(name, self, element_type='resource')
+    self.SetTemplateValue('rawClassName', raw_class_name)
+    class_name = self.ComputeNonDuplicatedName(raw_class_name)
     self.SetTemplateValue('className', class_name)
-    # Replace methods dict with Methods
-    self._methods = []
-    method_dict = self.values.get('methods') or {}
-    for name in sorted(method_dict):
-      self._methods.append(Method(api, name, method_dict[name], parent=self))
-    self.SetTemplateValue('methods', self._methods)
     # Get sub resources
     self._resources = []
     r_def_dict = self.values.get('resources') or {}
@@ -572,6 +567,13 @@ class Resource(template_objects.CodeObject):
       r = Resource(api, name, r_def_dict[name], parent=self)
       self._resources.append(r)
     self.SetTemplateValue('resources', self._resources)
+    # Replace methods dict with Methods
+    self._methods = []
+    method_dict = self.values.get('methods') or {}
+    for name in sorted(method_dict):
+      self._methods.append(Method(api, name, method_dict[name], parent=self))
+    self.SetTemplateValue('methods', self._methods)
+
 
   @property
   def methods(self):
@@ -666,11 +668,8 @@ class Method(template_objects.CodeObject):
     # then eliminate this line.
     self.SetTemplateValue('wireName', name)
     self.ValidateName(name)
-    class_name = api.ToClassName(name, self, element_type='method')
-    if parent and class_name == parent.values['className']:
-      # Some languages complain when the collection name is the same as the
-      # method name.
-      class_name = '%sRequest' % class_name
+    raw_class_name = api.ToClassName(name, self, element_type='method')
+    class_name = self.ComputeNonDuplicatedName(raw_class_name)
     # The name is the key of the dict defining use. The id field is what you
     # have to use to call the method via RPC. That is unique, name might not be.
     self.SetTemplateValue('name', name)
@@ -740,7 +739,8 @@ class Method(template_objects.CodeObject):
     req_parameters.sort(lambda x, y: cmp(order.index(x.values['wireName']),
                                          order.index(y.values['wireName'])))
     # sort optional parameters by name to avoid code churn
-    opt_parameters.sort(lambda x, y: cmp(x.values['wireName'], y.values['wireName']))
+    opt_parameters.sort(
+      lambda x, y: cmp(x.values['wireName'], y.values['wireName']))
     req_parameters.extend(opt_parameters)
     self.SetTemplateValue('parameters', req_parameters)
 

--- a/generator/src/googleapis/codegen/languages/java/2.0.0/templates/_resource.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/2.0.0/templates/_resource.tmpl
@@ -4,12 +4,12 @@
  * <p>The typical use is:</p>
  * <pre>
  *   {@code {{ api.className }} {{ api.name }} = new {{ api.className }}(...);}
- *   {@code {{ api.className }}.{{ resource.className }}.List request = {{ api.name }}.{{ resource.codeName }}().list(parameters ...)}
+ *   {@code {{ api.className }}.{{ resource.className }}.List request = {{ api.name }}.{{ resource.lowerClassName }}().list(parameters ...)}
  * </pre>
  *
  * @return the resource collection
  */
-public {{ resource.className }} {{ resource.codeName }}() {
+public {{ resource.className }} {{ resource.lowerClassName }}() {
   return new {{ resource.className }}();
 }
 

--- a/generator/tests/testdata/duplicated.v1.json
+++ b/generator/tests/testdata/duplicated.v1.json
@@ -1,0 +1,84 @@
+{
+  "name": "duplicatedApi",
+  "version": "v1",
+  "description": "Discovery used to test class names duplication in Java",
+  "restBasePath": "/duplicated/v1/",
+  "rpcPath": "/rpc",
+  "features": [
+    "dataWrapper"
+  ],
+  "schemas": {
+    "DuplicatedCurrentlocationGetResponseJson": "{\"id\":\"DuplicatedCurrentlocationGetResponseJson\",\"$ref\":\"DuplicatedLocationResourceJson\"}",
+    "DuplicatedCurrentlocationResourceJson": "{\"id\":\"DuplicatedCurrentlocationResourceJson\",\"$ref\":\"DuplicatedLocationResourceJson\"}",
+    "DuplicatedLocationListResponse": "{\"id\":\"DuplicatedLocationListResponse\",\"properties\":{\"items\":{\"items\":{\"$ref\":\"DuplicatedLocationResourceJson\"},\"type\":\"array\"},\"kind\":{\"default\":\"duplicated#locationFeed\",\"type\":\"string\"}},\"type\":\"object\"}",
+    "DuplicatedLocationResourceJson": "{\"id\":\"DuplicatedLocationResourceJson\",\"properties\":{\"placeid\":{\"type\":\"any\"},\"speed\":{\"type\":\"any\"},\"timestampMs\":{\"type\":\"any\"},\"altitude\":{\"type\":\"any\"},\"longitude\":{\"type\":\"any\"},\"foo\":{\"type\":\"any\"},\"accuracy\":{\"type\":\"any\"},\"altitudeAccuracy\":{\"type\":\"any\"},\"heading\":{\"type\":\"any\"},\"kind\":{\"default\":\"foo#location\",\"type\":\"string\"}},\"type\":\"object\"}"
+  },
+  "resources": {
+    "duplicated": {
+      "methods": {
+        "duplicated": {
+          "restPath": "duplicated",
+          "rpcMethod": "duplicated.duplicated.foo",
+          "httpMethod": "DELETE"
+        }
+      },
+      "resources": {
+        "duplicated": {
+          "methods": {
+            "duplicated": {
+              "restPath": "duplicated",
+              "rpcMethod": "duplicated.duplicated.foo",
+              "httpMethod": "DELETE"
+            }
+          },
+          "resources": {
+            "duplicated" : {
+              "methods": {
+                "duplicated": {
+                  "restPath": "duplicated",
+                  "rpcMethod": "duplicated.duplicated.foo",
+                  "httpMethod": "DELETE"
+                }
+              },
+              "resources": {
+                "duplicated":{
+                  "methods": {},
+                  "resources": {
+                    "duplicated": {
+                      "methods": {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "nonduplicated": {
+          "methods": {
+            "duplicated": {
+              "restPath": "duplicated",
+              "rpcMethod": "duplicated.duplicated.foo",
+              "httpMethod": "DELETE"
+            },
+            "nonduplicated": {
+              "restPath": "nonduplicated",
+              "rpcMethod": "nonduplicated.duplicated.foo",
+              "httpMethod": "DELETE"
+            }
+          },
+          "resources": {
+            "duplicated": {
+              "methods": {
+                "duplicated": {
+                  "restPath": "duplicated",
+                  "rpcMethod": "duplicated.duplicated.foo",
+                  "httpMethod": "DELETE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a preview PR to expose how class duplications would be handled

### Why not a PR against `main`
I submitted this PR against `generation-test` instead of `main` because it is outdated (if it was against `main` it would include changes to be added in the next generation cycle that are related to _discovery doc updates_ rather than changes in the generator).

### Identity Toolkit V1
```
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /usr/local/google/home/diegomarquezp/Desktop/google-api-java-client-services/clients/google-api-services-identitytoolkit/v1/2.0.0/com/google/api/services/identitytoolkit/v1/IdentityToolkit.java:[5867,144] package com.google.api.services.identitytoolkit.v1.model.IdentityToolkit.V1.GetPublicKeys does not exist
[ERROR] /usr/local/google/home/diegomarquezp/Desktop/google-api-java-client-services/clients/google-api-services-identitytoolkit/v1/2.0.0/com/google/api/services/identitytoolkit/v1/IdentityToolkit.java:[5886,142] package com.google.api.services.identitytoolkit.v1.model.IdentityToolkit.V1.GetPublicKeys does not exist
[INFO] 2 errors 
```