### PR TITLE
feat: handle duplicate class names

### DIFF
--- a/generator/src/googleapis/codegen/api.py
+++ b/generator/src/googleapis/codegen/api.py
@@ -33,8 +33,8 @@ __author__ = 'aiuto@google.com (Tony Aiuto)'
 import json
 import logging
 import operator
+import re
 import urlparse
-
 
 from googleapis.codegen import data_types
 from googleapis.codegen import template_objects
@@ -330,7 +330,7 @@ class Api(template_objects.CodeObject):
       self._api.SetTemplateValue('rootUrl', '%s://%s/' % (scheme, service_host))
     if service_path is None:
       self._api.SetTemplateValue('servicePath', base_path[1:])
-    
+
     # TODO(sijunliu): remove this once mtlsRootUrl is available in all services.
     if not self.values.get('mtlsRootUrl') and root_url:
       mtls_root_url = root_url.replace('googleapis.com', 'mtls.googleapis.com')
@@ -353,7 +353,7 @@ class Api(template_objects.CodeObject):
     return [m for m in self.ModelClasses() if not m.parent]
 
   def DataTypeFromJson(self, type_dict, default_name, parent=None,
-                       wire_name=None):
+      wire_name=None):
     """Returns a schema object represented by a JSON Schema dictionary.
 
     Evaluate a JSON schema dictionary and return an appropriate schema object.
@@ -558,6 +558,7 @@ class Resource(template_objects.CodeObject):
     super(Resource, self).__init__(def_dict, api, parent=parent, wire_name=name)
     self.ValidateName(name)
     class_name = api.ToClassName(name, self, element_type='resource')
+    class_name = self.ComputeNonDuplicatedName(class_name)
     self.SetTemplateValue('className', class_name)
     # Replace methods dict with Methods
     self._methods = []
@@ -572,6 +573,7 @@ class Resource(template_objects.CodeObject):
       r = Resource(api, name, r_def_dict[name], parent=self)
       self._resources.append(r)
     self.SetTemplateValue('resources', self._resources)
+
 
   @property
   def methods(self):
@@ -671,6 +673,7 @@ class Method(template_objects.CodeObject):
       # Some languages complain when the collection name is the same as the
       # method name.
       class_name = '%sRequest' % class_name
+    class_name = self.ComputeNonDuplicatedName(class_name)
     # The name is the key of the dict defining use. The id field is what you
     # have to use to call the method via RPC. That is unique, name might not be.
     self.SetTemplateValue('name', name)
@@ -740,7 +743,8 @@ class Method(template_objects.CodeObject):
     req_parameters.sort(lambda x, y: cmp(order.index(x.values['wireName']),
                                          order.index(y.values['wireName'])))
     # sort optional parameters by name to avoid code churn
-    opt_parameters.sort(lambda x, y: cmp(x.values['wireName'], y.values['wireName']))
+    opt_parameters.sort(
+      lambda x, y: cmp(x.values['wireName'], y.values['wireName']))
     req_parameters.extend(opt_parameters)
     self.SetTemplateValue('parameters', req_parameters)
 

--- a/generator/tests/template_objects_test.py
+++ b/generator/tests/template_objects_test.py
@@ -73,7 +73,7 @@ class TemplateObjectsTest(basetest.TestCase):
                                       language_model=self.language_model)
     bar = template_objects.CodeObject({'className': 'Bar'}, None, parent=foo)
     baz = template_objects.CodeObject({'className': 'Baz'}, None, parent=bar)
-    self.assertEquals(['Foo', 'Bar'], baz.parentPath)
+    self.assertEquals(['Foo', 'Bar'], baz.parentPath())
 
   def _TestRender(self, source, ctxt, expected):
     t = django_template.Template(source)


### PR DESCRIPTION
This PR adds duplication handling logic for `Resources` or `Methods`. For example, a _nested_ class `Foo.Bar.Foo` would be renamed to `Foo.Bar.Foo1`. Similarly, siblings would also be renamed (e.g. two `Foo.Sibling` classes would have one of them named as `Foo.Sibling1`. More than one repetition would append `2` instead of `1`, and so on.

### Preview changes
see https://github.com/googleapis/google-api-java-client-services/pull/16576

### Fixed libraries
Running the `generator` with the deduplication logic ended up altering the following libraries, all of which could not compile initially, due to class duplication. However, `identitytoolkit` happened to reveal an error seemingly unrelated to class duplication (see below).

- [x] apigee/v1 - fixed
- [x] assuredworkloads/v1beta1 - fixed
- [x] bigtableadmin/v2 - fixed
- [ ] identitytoolkit/v1 - _not-fixed_
- [x] monitoring/v1 - fixed
- [x] prod_tt_sasportal/v1alpha1 - fixed
- [x] sasportal/v1alpha1 - fixed
- [x] videointelligence/v1 - fixed

The generation was ran over _all_ of the libraries, but only those with duplication problems were detected as changed by git.

### Identity Toolkit V1
```
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /usr/local/google/home/diegomarquezp/Desktop/google-api-java-client-services/clients/google-api-services-identitytoolkit/v1/2.0.0/com/google/api/services/identitytoolkit/v1/IdentityToolkit.java:[5867,144] package com.google.api.services.identitytoolkit.v1.model.IdentityToolkit.V1.GetPublicKeys does not exist
[ERROR] /usr/local/google/home/diegomarquezp/Desktop/google-api-java-client-services/clients/google-api-services-identitytoolkit/v1/2.0.0/com/google/api/services/identitytoolkit/v1/IdentityToolkit.java:[5886,142] package com.google.api.services.identitytoolkit.v1.model.IdentityToolkit.V1.GetPublicKeys does not exist
[INFO] 2 errors 
```