### PR TITLE
fix: Update codegen.yaml to generate clients in 2 batches and 200 clients per batch

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -1,7 +1,7 @@
 on:
   schedule:
-    # every one hour from 00:30 to 03:30
-    - cron: '30 0-3 * * *'
+    # every one hour from 00:30 to 02:30
+    - cron: '30 0-2 * * *'
   workflow_dispatch:
 
 name: codegen
@@ -17,7 +17,7 @@ jobs:
         with:
           script: |
             console.log('checking size of services')
-            const MAX_SERVICE_SIZE = 400 // 00:30 to 03:30 implies 4 batches of size 100
+            const MAX_SERVICE_SIZE = 300 // 00:30 to 02:30 implies 3 batches of size 100
             const services = ${{ needs.discovery.outputs.services }}
             if (services.length > MAX_SERVICE_SIZE) {
               throw new Error(`Total services (${services.length}) exceed limit of ${MAX_SERVICE_SIZE}`)

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -1,7 +1,7 @@
 on:
   schedule:
-    # every one hour from 00:30 to 02:30
-    - cron: '30 0-2 * * *'
+    # Runs at 00:30 and 02:30.
+    - cron: '30 0,2 * * *'
   workflow_dispatch:
 
 name: codegen
@@ -17,7 +17,7 @@ jobs:
         with:
           script: |
             console.log('checking size of services')
-            const MAX_SERVICE_SIZE = 300 // 00:30 to 02:30 implies 3 batches of size 100
+            const MAX_SERVICE_SIZE = 400 // 00:30 and 02:30 implies 2 batches of size 200
             const services = ${{ needs.discovery.outputs.services }}
             if (services.length > MAX_SERVICE_SIZE) {
               throw new Error(`Total services (${services.length}) exceed limit of ${MAX_SERVICE_SIZE}`)
@@ -35,7 +35,7 @@ jobs:
             console.log('splitting service names list into batches')
             const services = ${{ needs.discovery.outputs.services }}
             const hour = new Date().getHours()
-            const MAX_BATCH_SIZE = 100
+            const MAX_BATCH_SIZE = 200
             const result = {
               batches: [],
               hour: new Date().getHours(),


### PR DESCRIPTION
The current codegen.yaml generates clients in 4 batches and 100 clients per batch, which makes the last batch always succeeds due to the number of services is less than 300 at this moment.  Changing the batch size to 2 and number of clients per batch to 200 so that the build status is correctly reflected. 
We need to manually increase the batch size once the number of clients is greater than 400, but it should be years from now.