### PR TITLE
fix: MediaContent is a non-nullable parameter

### DIFF
--- a/generator/src/googleapis/codegen/languages/java/2.0.0/templates/_method.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/2.0.0/templates/_method.tmpl
@@ -163,7 +163,7 @@ public class {{ method.className }} extends {{ api.className }}Request<{{ method
    *
    * {% for param in method.requiredParameters %}@param {{ param.memberName }} {% emit_parameter_doc param %}{% endfor %}{% if method.requestType %}
    * @param content the {@link {{ method.requestType.fullClassName }}} media metadata or {@code null} if none{% endif %}
-   * @param mediaContent The media HTTP content or {@code null} if none.
+   * @param mediaContent The media HTTP content.
    * @since 1.13
    */
   protected {{ method.className }}({% parameter_list %}
@@ -181,6 +181,7 @@ public class {{ method.className }} extends {{ api.className }}Request<{{ method
   {% for param in method.requiredParameters %}
     this.{{ param.memberName }} = com.google.api.client.util.Preconditions.checkNotNull({{ param.memberName }}, "Required parameter {{ param.memberName }} must be specified.");
   {% endfor %}
+    com.google.api.client.util.Preconditions.checkNotNull({{ mediaContent }}, "Required parameter {{ mediaContent }} must be specified.");
     initializeMediaUpload(mediaContent);
   {% call_template _alt_def method=method %}
   }


### PR DESCRIPTION
Reproducer Code with `com.google.apis:google-api-services-drive:v3-rev20230822-2.0.0`:
```
    GoogleCredentials credentials = GoogleCredentials.getApplicationDefault()
            .createScoped(Arrays.asList(DriveScopes.DRIVE_FILE));
    HttpRequestInitializer requestInitializer = new HttpCredentialsAdapter(
            credentials);

    // Build a new authorized API client service.
    Drive drive = new Drive.Builder(new NetHttpTransport(),
            GsonFactory.getDefaultInstance(),
            requestInitializer)
            .setApplicationName("Drive samples")
            .build();
    File file = new File();
    drive.files().update("test", file, null);
```

Results in:
```
Exception in thread "main" java.lang.NullPointerException
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:903)
	at com.google.api.client.util.Preconditions.checkNotNull(Preconditions.java:125)
	at com.google.api.client.googleapis.media.MediaHttpUploader.<init>(MediaHttpUploader.java:261)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.initializeMediaUpload(AbstractGoogleClientRequest.java:358)
	at com.google.api.services.drive.Drive$Files$Update.<init>(Drive.java:6838)
	at com.google.api.services.drive.Drive$Files.update(Drive.java:6774)
	at org.example.Main.main(Main.java:29)
```

----
### Fix

Removing the Javadoc section that states the mediaContent is allowed to be null. This contradicts with the implementation: https://github.com/googleapis/google-api-java-client/blob/c6c29a151cef78182d48bdacfa7a7ae36cda3376/google-api-client/src/main/java/com/google/api/client/googleapis/media/MediaHttpUploader.java#L261 that checks that mediaContent is not-null.

This should not be a behavior breaking change as setting a nullable mediaContent has never worked. We are adding a null check to ensure that mediaContent is not passed in a null value.

There is a duplicate method that users can use if they don't want to pass in a MediaContent: https://github.com/googleapis/google-api-java-client-services/blob/39b7762d08e7fd235a3425b3f381ad0cf4fa92ef/clients/google-api-services-drive/v2/2.0.0/com/google/api/services/drive/Drive.java#L9311-L9314

Fixes: #16932