### PR TITLE
fix: Copy latest variant's README to root README

### DIFF
--- a/.github/workflows/generate.sh
+++ b/.github/workflows/generate.sh
@@ -28,6 +28,7 @@ then
   exit 1
 fi
 
+# Default to use the latest variant
 if [[ -z "${VARIANT}" ]]
 then
   VARIANT=${LATEST_VARIANT}
@@ -54,6 +55,7 @@ do
       --language_variant=${VARIANT} \
       --package_path=api/services
 
-  # copy the latest README to the main service location
+  # Copy the latest variant's README to the main service location
+  # Generation of libraries with older variants should not update the root README
   cp ${ROOT_DIR}/google-api-java-client-services/clients/google-api-services-${SERVICE}/${VERSION}/${LATEST_VARIANT}/README.md ${ROOT_DIR}/google-api-java-client-services/clients/google-api-services-${SERVICE}/${VERSION}/README.md
 done

--- a/.github/workflows/generate.sh
+++ b/.github/workflows/generate.sh
@@ -20,6 +20,8 @@ SERVICE=$1
 VARIANT=$2
 ROOT_DIR=$(realpath $(dirname "${BASH_SOURCE[0]}")/../../../)
 
+LATEST_VARIANT=2.0.0
+
 if [[ -z "${SERVICE}" ]]
 then
   echo "Usage: ${0} <service> [variant]"
@@ -28,7 +30,7 @@ fi
 
 if [[ -z "${VARIANT}" ]]
 then
-  VARIANT=2.0.0
+  VARIANT=${LATEST_VARIANT}
 fi
 
 # Install the local generator without dependencies first and then install the dependencies with hash checking.
@@ -51,4 +53,7 @@ do
       --language=java \
       --language_variant=${VARIANT} \
       --package_path=api/services
+
+  # copy the latest README to the main service location
+  cp ${ROOT_DIR}/google-api-java-client-services/clients/google-api-services-${SERVICE}/${VERSION}/${LATEST_VARIANT}/README.md ${ROOT_DIR}/google-api-java-client-services/clients/google-api-services-${SERVICE}/${VERSION}/README.md
 done


### PR DESCRIPTION
The latest variant's README will be copied over to the library's root README on generation. Hardcode the latest version to be 2.0.0 (which will need to be updated if a new variant is created). 

Variant is set to be the latest variant (i.e. `2.0.0`) if there is no variant input, which allows us to generate new clients for old variants (i.e. `1.x.x`) if it's ever needed. Generating older variants would not have the README be copied over to the library's root README section.

Fixes: https://github.com/googleapis/google-api-java-client-services/issues/16629