### PR TITLE
fix: replace whole library source when generating libraries

### DIFF
--- a/.github/workflows/generate.sh
+++ b/.github/workflows/generate.sh
@@ -43,7 +43,8 @@ pushd ${ROOT_DIR}/discovery-artifact-manager
 for DISCOVERY in `ls discoveries/${SERVICE}.*.json`
 do
   VERSION=$(basename ${DISCOVERY} | sed 's/\.json//' | cut -d. -f2-)
-  OUTPUT_DIR=${ROOT_DIR}/google-api-java-client-services/clients/google-api-services-${SERVICE}/${VERSION}/${VARIANT}
+  TARGET_DIR=${ROOT_DIR}/google-api-java-client-services/clients/google-api-services-${SERVICE}/${VERSION}/${VARIANT}
+  OUTPUT_DIR=$(mktemp -d)
   echo ${DISCOVERY}
   echo ${VERSION}
   echo ${OUTPUT_DIR}
@@ -55,7 +56,16 @@ do
       --language_variant=${VARIANT} \
       --package_path=api/services
 
+  if [ $(find "${OUTPUT_DIR}" -mindepth 1 | wc -l) == '0' ]; then
+    echo 'the generation produced no files'
+    exit 1
+  fi
+
+  rm -rdf ${TARGET_DIR}/*
+  cp -r ${OUTPUT_DIR}/* "${TARGET_DIR}"
+
   # Copy the latest variant's README to the main service location
   # Generation of libraries with older variants should not update the root README
   cp ${ROOT_DIR}/google-api-java-client-services/clients/google-api-services-${SERVICE}/${VERSION}/${LATEST_VARIANT}/README.md ${ROOT_DIR}/google-api-java-client-services/clients/google-api-services-${SERVICE}/${VERSION}/README.md
 done
+

--- a/.github/workflows/generate.sh
+++ b/.github/workflows/generate.sh
@@ -61,6 +61,7 @@ do
     exit 1
   fi
 
+  # transfer generated source into the wiped-out service's source folder
   rm -rdf ${TARGET_DIR}/*
   cp -r ${OUTPUT_DIR}/* "${TARGET_DIR}"
 


### PR DESCRIPTION
Fixes #18823 ☕ 

This PR replaces the whole contents of a library with the new generated source code, causing deleted messages (via disc doc) to be deleted. This is the same behavior as GAPIC libraries

Confirmation after calling `.github/workflows/generate.sh playintegrity` produced the following modification

```
On branch generation-overwrite-fix
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	deleted:    ../../clients/google-api-services-playintegrity/v1/2.0.0/com/google/api/services/playintegrity/v1/model/AccountRiskVerdict.java

no changes added to commit (use "git add" and/or "git commit -a")
```