### PR TITLE
ci: Fix test CI job

### DIFF
--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -13,27 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-EXIT_STATUS=0
+# Fail only any non-zero status code
+set -e
 
 pushd $(dirname "$0")/../
 
-for directory in `find clients -mindepth 3 -maxdepth 3 -type d | sort`
+VARIANT="2.0.0"
+
+# Only search for directories with the latest variant as only the generator only
+# generates libraries for the latest variant
+for directory in `find clients -mindepth 3 -maxdepth 3 -type d | grep ${VARIANT} | sort`
 do
   pushd $directory
-  diff=$(git diff master .)
+  diff=$(git diff main .)
   if [ -z "$diff" ]; then
     # skipping tests
-    echo "No difference from master, skipping tests."
+    echo "No difference from main, skipping tests."
   else
     mvn clean verify package -Dclirr.skip=true -B
-    es=$?
-    if [ $es -ne 0 ]; then
-        EXIT_STATUS=$es
-    fi
   fi
   popd
 done
-
 popd
-
-exit $EXIT_STATUS

--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -18,7 +18,7 @@ set -e
 
 pushd $(dirname "$0")/../
 
-printenv
+git config --global --add safe.directory $(realpath .)
 
 VARIANT="2.0.0"
 

--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Fail only any non-zero status code
+# Fail on any non-zero status code
 set -e
 
 pushd $(dirname "$0")/../

--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -25,7 +25,7 @@ VARIANT="2.0.0"
 for directory in `find clients -mindepth 3 -maxdepth 3 -type d | grep ${VARIANT} | sort`
 do
   pushd $directory
-  diff=$(git diff main .)
+  diff=$(git diff "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH}...${KOKORO_GITHUB_PULL_REQUEST_COMMIT}")
   if [ -z "$diff" ]; then
     # skipping tests
     echo "No difference from main, skipping tests."

--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -18,6 +18,8 @@ set -e
 
 pushd $(dirname "$0")/../
 
+printenv
+
 VARIANT="2.0.0"
 
 # Only search for directories with the latest variant as only the generator only

--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -32,8 +32,8 @@ do
   # Find any diffs in the PR branch that are in this directory
   diff=$(git diff "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH}...${KOKORO_GITHUB_PULL_REQUEST_COMMIT}" -- "${directory}")
   if [ -z "$diff" ]; then
-    # skipping tests
-    echo "No differences found in the PR branch, skipping tests."
+    # Skip compilation + Running tests
+    echo "No differences found in the PR branch for ${directory}, skipping..."
   else
     mvn clean verify package -Dclirr.skip=true -Dmaven.javadoc.skip=true -B
   fi


### PR DESCRIPTION
Part of issue in b/307942373

An example of a previous run: https://source.cloud.google.com/results/invocations/c53db7a4-af9f-40b2-ba85-29cd10dd1808/targets/cloud-devrel%2Fclient-libraries%2Fjava%2Fgoogle-api-java-client-services%2Fpresubmit/log

Has logs:
```
/tmpfs/src/github/google-api-java-client-services /tmpfs/src
/tmpfs/src/github/google-api-java-client-services/clients/google-api-services-abusiveexperiencereport/v1/1.26.0 /tmpfs/src/github/google-api-java-client-services /tmpfs/src
error: Could not access 'master'
No difference from master, skipping tests.
/tmpfs/src/github/google-api-java-client-services /tmpfs/src
/tmpfs/src/github/google-api-java-client-services/clients/google-api-services-abusiveexperiencereport/v1/1.27.0 /tmpfs/src/github/google-api-java-client-services /tmpfs/src
error: Could not access 'master'
No difference from master, skipping tests.
```

This skips trying to compile the newly generated repo and does not fail the CI.

## Changes
- For now, compare the diffs in the PR against main to try and compile the changes. PRs that can't compile won't get merged in.
- Try to compile only the libraries generated on the latest variant