### PR TITLE
ci: Fix test CI job to check directory from root

### DIFF
--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -23,13 +23,13 @@ git config --global --add safe.directory $(realpath .)
 
 VARIANT="2.0.0"
 
-# Only search for directories with the latest variant as only the generator only
+# Only search for directories with the latest variant as the generator only
 # generates libraries for the latest variant
 for directory in `find clients -mindepth 3 -maxdepth 3 -type d | grep ${VARIANT} | sort`
 do
   # Find any diffs in the PR branch that are in this directory
   diff=$(git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH}...${KOKORO_GITHUB_PULL_REQUEST_COMMIT}" -- "${directory}")
-  if [ -z "$diff" ]; then
+  if [ -z "${diff}" ]; then
     # Skip compilation + Running tests
     echo "No differences found in the PR branch for ${directory}, skipping..."
   else

--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -27,17 +27,14 @@ VARIANT="2.0.0"
 # generates libraries for the latest variant
 for directory in `find clients -mindepth 3 -maxdepth 3 -type d | grep ${VARIANT} | sort`
 do
-  pushd $directory
-
   # Find any diffs in the PR branch that are in this directory
-  diff=$(git diff "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH}...${KOKORO_GITHUB_PULL_REQUEST_COMMIT}" -- "${directory}")
+  diff=$(git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH}...${KOKORO_GITHUB_PULL_REQUEST_COMMIT}" -- "${directory}")
   if [ -z "$diff" ]; then
     # Skip compilation + Running tests
     echo "No differences found in the PR branch for ${directory}, skipping..."
   else
+    echo "Found differences in ${directory}. Compiling..."
     mvn clean verify package -Dclirr.skip=true -Dmaven.javadoc.skip=true -B
   fi
-
-  popd
 done
 popd


### PR DESCRIPTION
Resolved issue from logs in this PR: https://github.com/googleapis/google-api-java-client-services/pull/18921 -- The diffs aren't being compared properly.

No diffs were found because the diffs are compared against each client's directory (i.e. $directory = `clients/google-api-services-webrisk/v1/2.0.0`).

The script would initially pushd into $directory and then search from there, but `clients/google-api-services-webrisk/v1/2.0.0/clients/google-api-services-webrisk/v1/2.0.0` path does not exist. This update removes the need to cd into $directory.

Fixes: https://github.com/googleapis/google-api-java-client-services/issues/18174