### PR TITLE
ci: Run mvn verify in the client directory

### DIFF
--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -33,8 +33,11 @@ do
     # Skip compilation + Running tests
     echo "No differences found in the PR branch for ${directory}, skipping..."
   else
+    # Run the mvn command in the directory
+    pushd "${directory}"
     echo "Found differences in ${directory}. Compiling..."
-    mvn clean verify package -Dclirr.skip=true -Dmaven.javadoc.skip=true -B
+    mvn verify -Dclirr.skip=true -Dmaven.javadoc.skip=true -B
+    popd
   fi
 done
 popd

--- a/clients/google-api-services-abusiveexperiencereport/v1/2.0.0/com/google/api/services/abusiveexperiencereport/v1/AbusiveExperienceReportRequest.java
+++ b/clients/google-api-services-abusiveexperiencereport/v1/2.0.0/com/google/api/services/abusiveexperiencereport/v1/AbusiveExperienceReportRequest.java
@@ -42,7 +42,6 @@ public abstract class AbusiveExperienceReportRequest<T> extends com.google.api.c
         uriTemplate,
         content,
         responseClass);
-    randomtext // This will fail compilation
   }
 
   /** V1 error format. */

--- a/clients/google-api-services-abusiveexperiencereport/v1/2.0.0/com/google/api/services/abusiveexperiencereport/v1/AbusiveExperienceReportRequest.java
+++ b/clients/google-api-services-abusiveexperiencereport/v1/2.0.0/com/google/api/services/abusiveexperiencereport/v1/AbusiveExperienceReportRequest.java
@@ -42,6 +42,7 @@ public abstract class AbusiveExperienceReportRequest<T> extends com.google.api.c
         uriTemplate,
         content,
         responseClass);
+    randomtext // This will fail compilation
   }
 
   /** V1 error format. */


### PR DESCRIPTION
Logs from latest run:
```
Found differences in clients/google-api-services-translate/v3/2.0.0. Compiling...
[INFO] Scanning for projects...
[INFO] 
[INFO] -------------< com.google.apis:google-api-services-parent >-------------
[INFO] Building Google APIs Client Library for Java 0.0.1-SNAPSHOT
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ google-api-services-parent ---
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.pom (4.1 kB at 6.7 kB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.jar
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.jar (226 kB at 2.2 MB/s)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.524 s
[INFO] Finished at: 2023-12-05T02:52:46Z
[INFO] ------------------------------------------------------------------------
```

This is running the command in the root directory and not in the correct directory
---
Running this locally for the latest commit shows:
```
...
[INFO] 
[INFO] <<< clirr-maven-plugin:2.8:check (default) < compile @ google-api-services-translate <<<
[INFO] 
[INFO] 
[INFO] --- clirr-maven-plugin:2.8:check (default) @ google-api-services-translate ---
[INFO] Skipping execution
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12.301 s
[INFO] Finished at: 2023-12-05T19:30:05Z
[INFO] ------------------------------------------------------------------------
```
which is running the job inside the correct directory.