### PR TITLE
chore: experiment with multipart upload

### DIFF
--- a/clients/google-api-services-storage/v1/2.0.0/com/google/api/services/storage/Main.java
+++ b/clients/google-api-services-storage/v1/2.0.0/com/google/api/services/storage/Main.java
@@ -1,0 +1,72 @@
+package com.google.api.services.storage;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.googleapis.media.MediaHttpUploader;
+import com.google.api.client.http.FileContent;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.InputStreamContent;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.storage.Storage.Objects.Insert;
+import com.google.api.services.storage.model.StorageObject;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class Main {
+
+  public static void main(String[] args) throws Exception {
+    Storage supportService = new Storage.Builder(
+        GoogleNetHttpTransport.newTrustedTransport(),
+        GsonFactory.getDefaultInstance(),
+        new HttpCredentialsAdapter(GoogleCredentials.getApplicationDefault()))
+        .setApplicationName("Cloud Support API")
+        .build();
+
+    Logger logger = Logger.getLogger(HttpTransport.class.getName());
+    ConsoleHandler consoleHandler = new ConsoleHandler();
+    consoleHandler.setLevel(Level.FINE);
+    logger.addHandler(consoleHandler);
+
+    // file to upload
+    java.net.URL resource = Main.class.getResource("/SOME_FILE.txt");
+    if (resource == null) {
+      throw new Exception("resource not found");
+    }
+    String filepath = resource.getFile();
+    File file = new File(filepath);
+    // perform upload
+    logger.setLevel(Level.FINE);
+    StorageObject object = new StorageObject();
+    object.setName("name1");
+
+    // resumable upload
+    // Insert request = supportService.objects()
+    //     .insert("special-bucket-1",
+    //         object,
+    //         new FileContent("text/plain", file));
+    // request.setUploadType("media");
+    // System.out.println(request.execute());
+
+    // direct upload
+    System.out.println("**************** direct upload ****************");
+    Insert directrequest = supportService.objects()
+        .insert("special-bucket-1",
+            object,
+            new FileContent("text/plain", file));
+    directrequest.getMediaHttpUploader().setDirectUploadEnabled(true);
+    directrequest.setUploadType("media");
+
+    System.out.println(directrequest.execute());
+  }
+
+}

--- a/clients/google-api-services-storage/v1/2.0.0/pom.xml
+++ b/clients/google-api-services-storage/v1/2.0.0/pom.xml
@@ -127,6 +127,11 @@
       <artifactId>google-api-client</artifactId>
       <version>2.2.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gapic-generator-java</artifactId>
+      <version>2.28.1-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/clients/google-api-services-storage/v1/2.0.0/resources/SOME_FILE.txt
+++ b/clients/google-api-services-storage/v1/2.0.0/resources/SOME_FILE.txt
@@ -1,0 +1,1 @@
+This is some file


### PR DESCRIPTION
This demonstrates that direct upload is not "respected" if we use the following [suggestion](https://github.com/googleapis/google-api-java-client/blob/main/docs/media-upload.md#direct-media-upload)
```
mediaHttpUploader.setDirectUploadEnabled(true);
```

The logger shows both requests with `?uploadType=multipart`