### PR TITLE
fix: generation of new libraries to create a new folder

### DIFF
--- a/.github/workflows/generate.sh
+++ b/.github/workflows/generate.sh
@@ -61,6 +61,8 @@ do
     exit 1
   fi
 
+  # for new libraries, we create the destination folder
+  mkdir -p "${TARGET_DIR}"
   # transfer generated source into the wiped-out service's source folder
   rm -rdf ${TARGET_DIR}/*
   cp -r ${OUTPUT_DIR}/* "${TARGET_DIR}"


### PR DESCRIPTION
The `generate.sh` script will not create a new folder for new libraries (see firebaseappdistribution https://github.com/googleapis/google-api-java-client-services/actions/runs/7161872428/job/19498082586)

This fixes this