### PR TITLE
chore: add check to create list of non-compilable libraries

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -19,8 +19,6 @@ jobs:
           path: google-api-java-client-services
       # we install the moreutils `parallel` command
       - run: sudo apt-get install moreutils
-      - run: ls /usr/bin/parallel*
-      - run: ls /bin/parallel*
       - working-directory: google-api-java-client-services
         run: bash .github/workflows/verify_compilation.sh
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -19,6 +19,8 @@ jobs:
           path: google-api-java-client-services
       # we install the moreutils `parallel` command
       - run: sudo apt-get install moreutils
+      - run: ls /usr/bin/parallel*
+      - run: ls /bin/parallel*
       - working-directory: google-api-java-client-services
         run: bash .github/workflows/verify_compilation.sh
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 # Generates a list of libraries that cannot be
 # compiled (printed to the action stdout)
-name: Verify library compilation
+name: Verify libraries compilation
 jobs:
   verify:
     runs-on: ubuntu-20.04
@@ -14,5 +14,5 @@ jobs:
         with:
           distribution: temurin
           java-version: 8
-      - run: bash .github/workflows/verify_compilation.sh
+      - run: bash ./google-api-java-client-services/.github/workflows/verify_compilation.sh
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -14,5 +14,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 8
+      - uses: actions/checkout@v2
+        with:
+          path: google-api-java-client-services
       - run: bash ./google-api-java-client-services/.github/workflows/verify_compilation.sh
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-java@v3
-      with:
-        distribution: temurin
-        java-version: 7
+        with:
+          distribution: temurin
+          java-version: 7
       - run: bash .github/workflows/verify_compilation.sh
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -19,6 +19,7 @@ jobs:
           path: google-api-java-client-services
       # we install the moreutils `parallel` command
       - run: sudo apt-get install moreutils
+      - run: type -a parallel
       - working-directory: google-api-java-client-services
         run: bash .github/workflows/verify_compilation.sh
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,0 +1,18 @@
+on:
+  schedule:
+    # Runs at 04:00 am
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+# Generates a list of libraries that cannot be
+# compiled (printed to the action stdout)
+name: Verify library compilation
+jobs:
+  verify:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 7
+      - run: bash .github/workflows/verify_compilation.sh
+

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -17,5 +17,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: google-api-java-client-services
-      - run: bash ./google-api-java-client-services/.github/workflows/verify_compilation.sh
+      - working-directory: google-api-java-client-services
+        run: bash .github/workflows/verify_compilation.sh
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 7
+          java-version: 8
       - run: bash .github/workflows/verify_compilation.sh
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -19,7 +19,6 @@ jobs:
           path: google-api-java-client-services
       # we install the moreutils `parallel` command
       - run: sudo apt-get install moreutils
-      - run: type -a parallel
       - working-directory: google-api-java-client-services
         run: bash .github/workflows/verify_compilation.sh
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           path: google-api-java-client-services
       # we install the moreutils `parallel` command
-      - run: apt install moreutils
+      - run: sudo apt-get install moreutils
       - working-directory: google-api-java-client-services
         run: bash .github/workflows/verify_compilation.sh
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: google-api-java-client-services
+      # we install the moreutils `parallel` command
+      - run: apt install moreutils
       - working-directory: google-api-java-client-services
         run: bash .github/workflows/verify_compilation.sh
 

--- a/.github/workflows/verify_compilation.sh
+++ b/.github/workflows/verify_compilation.sh
@@ -34,8 +34,13 @@ if [[ -f "${failed_libs}" ]];then
   rm "${failed_libs}"
 fi
 pushd "${repo_root}"
+
+# some distros rename parallel to parallel.moreutils
+parallel_bin="parallel.moreutils"
+which parallel.moreutils || parallel_bin="parallel"
+
 # runs mvn compile in parallel (max 20 jobs)
-/bin/parallel -j50 -i bash -xe -c 'process_client "{}"' -- $(find . -mindepth 3 -name '*pom.xml' -printf '%p ')
+${parallel_bin} -j50 -i bash -xe -c 'process_client "{}"' -- $(find . -mindepth 3 -name '*pom.xml' -printf '%p ')
 
 print_failed_libraries
 

--- a/.github/workflows/verify_compilation.sh
+++ b/.github/workflows/verify_compilation.sh
@@ -35,7 +35,7 @@ if [[ -f "${failed_libs}" ]];then
 fi
 pushd "${repo_root}"
 # runs mvn compile in parallel (max 20 jobs)
-parallel -j50 -i bash -xe -c 'process_client "{}"' -- $(find . -mindepth 3 -name '*pom.xml' -printf '%p ')
+/bin/parallel -j50 -i bash -xe -c 'process_client "{}"' -- $(find . -mindepth 3 -name '*pom.xml' -printf '%p ')
 
 print_failed_libraries
 

--- a/.github/workflows/verify_compilation.sh
+++ b/.github/workflows/verify_compilation.sh
@@ -7,8 +7,7 @@ export repo_root=$(git rev-parse --show-toplevel)
 export failed_libs="${repo_root}/failed_libs"
 
 process_client() {
-  pom=$1
-  pom_dir=$(dirname "${pom}")
+  pom_dir=$1
   pushd "${pom_dir}"
   lib_name=$(pwd | sed 's/.*\(google-api-services-.*\)/\1/')
   mvn compile || echo "${lib_name}" >> "${failed_libs}"
@@ -40,7 +39,7 @@ parallel_bin="parallel.moreutils"
 which parallel.moreutils || parallel_bin="parallel"
 
 # runs mvn compile in parallel (max 50 jobs)
-${parallel_bin} -j50 -i bash -xe -c 'process_client "{}"' -- $(find . -mindepth 3 -name '*pom.xml' -printf '%p ')
+${parallel_bin} -j50 -i bash -xe -c 'process_client "{}"' -- $(find "clients" -mindepth 3 -name '*2.0.0*' -printf '%p ')
 
 print_failed_libraries
 

--- a/.github/workflows/verify_compilation.sh
+++ b/.github/workflows/verify_compilation.sh
@@ -39,7 +39,7 @@ pushd "${repo_root}"
 parallel_bin="parallel.moreutils"
 which parallel.moreutils || parallel_bin="parallel"
 
-# runs mvn compile in parallel (max 20 jobs)
+# runs mvn compile in parallel (max 50 jobs)
 ${parallel_bin} -j50 -i bash -xe -c 'process_client "{}"' -- $(find . -mindepth 3 -name '*pom.xml' -printf '%p ')
 
 print_failed_libraries

--- a/.github/workflows/verify_compilation.sh
+++ b/.github/workflows/verify_compilation.sh
@@ -28,8 +28,15 @@ print_failed_libraries() {
 # export process_client so it can be accessed by the inner shell launched by the
 # find command
 export -f process_client
+# for convenience in local setups, we remove the failed libraries list
+# beforehand
+if [[ -f "${failed_libs}" ]];then
+  rm "${failed_libs}"
+fi
 pushd "${repo_root}"
-find . -name 'pom.xml' -exec bash -xe -c 'process_client "$0"' {} \;
+# runs mvn compile in parallel (max 20 jobs)
+parallel -j50 -i bash -xe -c 'process_client "{}"' -- $(find . -mindepth 3 -name '*pom.xml' -printf '%p ')
+
 print_failed_libraries
 
 

--- a/.github/workflows/verify_compilation.sh
+++ b/.github/workflows/verify_compilation.sh
@@ -27,7 +27,7 @@ print_failed_libraries() {
 
 # export process_client so it can be accessed by the inner shell launched by the
 # find command
-export -f print_failed_libraries
+export -f process_client
 pushd "${repo_root}"
 find . -name 'pom.xml' -exec bash -c 'process_client "$0"' {} \;
 print_failed_libraries

--- a/.github/workflows/verify_compilation.sh
+++ b/.github/workflows/verify_compilation.sh
@@ -29,7 +29,7 @@ print_failed_libraries() {
 # find command
 export -f process_client
 pushd "${repo_root}"
-find . -name 'pom.xml' -exec bash -c 'process_client "$0"' {} \;
+find . -name 'pom.xml' -exec bash -xe -c 'process_client "$0"' {} \;
 print_failed_libraries
 
 

--- a/.github/workflows/verify_compilation.sh
+++ b/.github/workflows/verify_compilation.sh
@@ -3,7 +3,7 @@
 # create a list of clients that cannot be compiled. The resulting list is
 # printed to stdout
 set -exo
-export repo_root=$(git rev-parse --show-toplevel)
+repo_root=$(git rev-parse --show-toplevel)
 export failed_libs="${repo_root}/failed_libs"
 
 process_client() {

--- a/.github/workflows/verify_compilation.sh
+++ b/.github/workflows/verify_compilation.sh
@@ -39,7 +39,12 @@ parallel_bin="parallel.moreutils"
 which parallel.moreutils || parallel_bin="parallel"
 
 # runs mvn compile in parallel (max 50 jobs)
-${parallel_bin} -j50 -i bash -xe -c 'process_client "{}"' -- $(find "clients" -mindepth 3 -name '*2.0.0*' -printf '%p ')
+targets=$(find "clients" -mindepth 3 -name '*2.0.0*' -printf '%p ')
+echo "Attempting compilation on the following libraries:"
+set +x
+echo "${targets}" | sed 's/ /\n/g' | sort
+set -x
+${parallel_bin} -j50 -i bash -xe -c 'process_client "{}"' -- ${targets}
 
 print_failed_libraries
 

--- a/.github/workflows/verify_compilation.sh
+++ b/.github/workflows/verify_compilation.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# This script loops over the generated clients and uses `mvn compile` to
+# create a list of clients that cannot be compiled. The resulting list is
+# printed to stdout
+set -exo
+export repo_root=$(git rev-parse --show-toplevel)
+export failed_libs="${repo_root}/failed_libs"
+
+process_client() {
+  pom=$1
+  pom_dir=$(dirname "${pom}")
+  pushd "${pom_dir}"
+  lib_name=$(pwd | sed 's/.*\(google-api-services-.*\)/\1/')
+  mvn compile || echo "${lib_name}" >> "${failed_libs}"
+  popd #pom_dir
+}
+
+print_failed_libraries() {
+  if [[ $(cat "${failed_libs}" | wc -l) -ne 0 ]]; then
+    echo "The following libraries had compilation errors:"
+    cat "${failed_libs}"
+    exit 1
+  else
+    echo "All libraries were compiled successfully!"
+  fi
+}
+
+# export process_client so it can be accessed by the inner shell launched by the
+# find command
+export -f print_failed_libraries
+pushd "${repo_root}"
+find . -name 'pom.xml' -exec bash -c 'process_client "$0"' {} \;
+print_failed_libraries
+
+
+popd #repo_root


### PR DESCRIPTION
This new check runs at 4am every day and runs `mvn compile` on every client at the service-version level on template version 2.0.0 only. For example it would run once for
```
/google-api-services-example/v1/2.0.0
/google-api-services-example/v2/2.0.0
```

But it would not run for 
```
/google-api-services-example/v1/1.31.0
/google-api-services-example/v2/1.31.0
```

The compilations are run in parallel (max 50 jobs)

Every compilation failure will be printed at the end of the workflow ([example](https://github.com/diegomarquezp/google-api-java-client-services/actions/runs/8898906658)).

The last part of the workflow output is what matters:
```
2024-04-30T18:40:09.0018589Z The following libraries had compilation errors:
2024-04-30T18:40:09.0019604Z + echo 'The following libraries had compilation errors:'
2024-04-30T18:40:09.0021201Z + cat /home/runner/work/google-api-java-client-services/google-api-java-client-services/google-api-java-client-services/failed_libs
2024-04-30T18:40:09.0027988Z google-api-services-firestore/v1/1.27.0
2024-04-30T18:40:09.0028670Z + exit 1
2024-04-30T18:40:09.0029269Z google-api-services-firestore/v1beta2/1.31.0
2024-04-30T18:40:09.0030105Z google-api-services-realtimebidding/v1alpha/2.0.0
2024-04-30T18:40:09.0031055Z google-api-services-servicecontrol/v2/1.30.1
2024-04-30T18:40:09.0032095Z google-api-services-policytroubleshooter/v1beta/1.29.2
2024-04-30T18:40:09.0033045Z google-api-services-firestore/v1beta2/1.27.0
2024-04-30T18:40:09.0033931Z google-api-services-policytroubleshooter/v1/1.29.2
2024-04-30T18:40:09.0034790Z google-api-services-firestore/v1beta1/1.27.0
2024-04-30T18:40:09.0035551Z google-api-services-drive/v3/1.31.0
2024-04-30T18:40:09.0036347Z google-api-services-recaptchaenterprise/v1/1.31.0
2024-04-30T18:40:09.0037219Z google-api-services-datalineage/v1/2.0.0
2024-04-30T18:40:09.0038308Z google-api-services-recaptchaenterprise/v1/2.0.0
2024-04-30T18:40:09.0039176Z google-api-services-identitytoolkit/v1/2.0.0
2024-04-30T18:40:09.0039991Z google-api-services-videointelligence/v1/1.31.0
2024-04-30T18:40:09.0040877Z google-api-services-prod_tt_sasportal/v1alpha1/1.31.0
2024-04-30T18:40:09.0041739Z google-api-services-contentwarehouse/v1/2.0.0
2024-04-30T18:40:09.0042525Z google-api-services-monitoring/v1/1.31.0
2024-04-30T18:40:09.0043450Z google-api-services-integrations/v1alpha/2.0.0
2024-04-30T18:40:09.0044301Z google-api-services-bigtableadmin/v2/1.31.0
2024-04-30T18:40:09.0045074Z google-api-services-sasportal/v1alpha1/1.31.0
2024-04-30T18:40:09.0045806Z google-api-services-apigee/v1/1.31.0
2024-04-30T18:40:09.0210384Z ##[error]Process completed with exit code 1.
```