### PR TITLE
chore: Exclude contentwarehouse from daily generation.

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -44,7 +44,7 @@ jobs:
             const MAX_BATCH_SIZE = 100
             const result = {
               batches: [],
-              hour: 0,
+              hour: new Date().getHours(),
             };
             for (let i = 0; i < filteredServices.length; i += MAX_BATCH_SIZE) {
               result.batches.push(filteredServices.slice(i, i + MAX_BATCH_SIZE))

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -44,7 +44,7 @@ jobs:
             const MAX_BATCH_SIZE = 100
             const result = {
               batches: [],
-              hour: new Date().getHours(),
+              hour: 1,
             };
             for (let i = 0; i < filteredServices.length; i += MAX_BATCH_SIZE) {
               result.batches.push(filteredServices.slice(i, i + MAX_BATCH_SIZE))
@@ -58,6 +58,6 @@ jobs:
     # For example, a job starting at "1:30" uses the chunk at the index 1 in the array.
     # If you manually invoke the workflow other hours than 0:00 - 2:59 and the array's length is 3,
     # this job is skipped because there's no element at the index in the array.
-    if: ${{!!fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).1]}}
+    if: ${{!!fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour]}}
     with: 
       services: ${{toJson(fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour])}}

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -38,14 +38,16 @@ jobs:
           script: |
             console.log('splitting service names list into batches')
             const services = ${{ needs.discovery.outputs.services }}
+            const excludedServices = ['contentwarehouse']
+            const filteredServices = services.filter(item => !excludedServices.includes(item))
             const hour = new Date().getHours()
             const MAX_BATCH_SIZE = 100
             const result = {
               batches: [],
               hour: new Date().getHours(),
             };
-            for (let i = 0; i < services.length; i += MAX_BATCH_SIZE) {
-              result.batches.push(services.slice(i, i + MAX_BATCH_SIZE))
+            for (let i = 0; i < filteredServices.length; i += MAX_BATCH_SIZE) {
+              result.batches.push(filteredServices.slice(i, i + MAX_BATCH_SIZE))
             }
             return result
   generate:

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -44,7 +44,7 @@ jobs:
             const MAX_BATCH_SIZE = 100
             const result = {
               batches: [],
-              hour: 1,
+              hour: 0,
             };
             for (let i = 0; i < filteredServices.length; i += MAX_BATCH_SIZE) {
               result.batches.push(filteredServices.slice(i, i + MAX_BATCH_SIZE))

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -58,6 +58,6 @@ jobs:
     # For example, a job starting at "1:30" uses the chunk at the index 1 in the array.
     # If you manually invoke the workflow other hours than 0:00 - 2:59 and the array's length is 3,
     # this job is skipped because there's no element at the index in the array.
-    if: ${{!!fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour]}}
+    if: ${{!!fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).1]}}
     with: 
       services: ${{toJson(fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour])}}

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -39,7 +39,7 @@ jobs:
             console.log('splitting service names list into batches')
             const services = ${{ needs.discovery.outputs.services }}
             const excludedServices = ['contentwarehouse']
-            const filteredServices = services.filter(item => !excludedServices.includes(item))
+            const filteredServices = services.filter(service => !excludedServices.includes(service))
             const hour = new Date().getHours()
             const MAX_BATCH_SIZE = 100
             const result = {


### PR DESCRIPTION
Based on the [public doc](https://cloud.google.com/document-warehouse/docs/overview) of contentwarehouse, it is deprecated, we should remove it from our daily generation.