### PR TITLE
fix: remove duplicate set param functions when param exists in parent

### DIFF
--- a/generator/src/googleapis/codegen/api.py
+++ b/generator/src/googleapis/codegen/api.py
@@ -162,9 +162,6 @@ class Api(template_objects.CodeObject):
       self._top_level_methods.append(Method(self, name, method_dict[name]))
     self.SetTemplateValue('methods', self._top_level_methods)
 
-
-    # could remove here, if any parameter is also contained in method
-
     # Auth scopes
     self._authscopes = []
     if (self.values.get('auth') and

--- a/generator/src/googleapis/codegen/api.py
+++ b/generator/src/googleapis/codegen/api.py
@@ -137,8 +137,6 @@ class Api(template_objects.CodeObject):
     self._parameters = []
     param_dict = self.values.get('parameters') or {}
     for name in sorted(param_dict):
-      if (name == 'key'):
-        test = "true"
       parameter = Parameter(self, name, param_dict[name], self)
       self._parameters.append(parameter)
       if name == 'alt':


### PR DESCRIPTION
in the case that there is global parameter and its redeclared in the individual method declaration, remove the duplicate #19018 

after running generator with the new build it removes the second setKey function and only keeps the global function

` @Override
        public RetrieveLegacySecretKey setKey(java.lang.String key) {
          return (RetrieveLegacySecretKey) super.setKey(key);
        }
`

output of compilation
`[INFO] Installing /Users/ldetmer/workspace/google-api-java-client-services/generator/src/tmp/target/google-api-services-recaptchaenterprise-v1-rev20220505-2.0.0-javadoc.jar to /Users/ldetmer/.m2/repository/com/google/apis/google-api-services-recaptchaenterprise/v1-rev20220505-2.0.0/google-api-services-recaptchaenterprise-v1-rev20220505-2.0.0-javadoc.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.338 s
[INFO] Finished at: 2024-12-04T16:58:47-05:00
[INFO] ------------------------------------------------------------------------
`

Tested: generated all client libraries with new code
