### PR TITLE
docs: Update README with the new minimum Python version 3.6

### DIFF
--- a/generator/README
+++ b/generator/README
@@ -34,7 +34,7 @@ Introduction
 
 Installation
 
-Python 3.6 is required.  Python3 is not supported.
+Python 3.6 is required.  Python 2 is not supported.
 
 Everything can be installed quickly with easy_install or pip. E.g.:
 

--- a/generator/README
+++ b/generator/README
@@ -34,7 +34,7 @@ Introduction
 
 Installation
 
-Python 2.7 is required.  Python3 is not supported.
+Python 3.6 is required.  Python3 is not supported.
 
 Everything can be installed quickly with easy_install or pip. E.g.:
 


### PR DESCRIPTION
The minimum version to run the Apiary generator is now 3.6 per https://github.com/googleapis/google-api-java-client-services/pull/21574. Update the README to reflect it.