### PR TITLE
Update runners to ubuntu-24.04 from deprecated ubuntu-20.04 label

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -10,7 +10,7 @@ jobs:
     # As of November 2023, it returns 269 service names.
     uses: googleapis/discovery-artifact-manager/.github/workflows/list-services.yml@master
   total_service_size_check:
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     needs: discovery
     steps:
       - uses: actions/github-script@v5
@@ -24,7 +24,7 @@ jobs:
               throw new Error(`Total services (${services.length}) exceed limit of ${MAX_SERVICE_SIZE}`)
             }
   batch:
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     needs: discovery
     outputs:
       # As of November 2023, the output of batch job is a 3-element array, which contains a chunk of 100 service names


### PR DESCRIPTION
This is a LSC run by http://go/ghss to upgrade all depreacated ubuntu-20.04 runners to ubuntu-24.04.

On April 1, 2025, GitHub will stop supporting ubuntu-20.04 runners and workflows configured with this label will cease to run.  This PR is an attempt to save you work by doing the upgrade for you.

WARNING: We do not know if the updated label is compatiable with your workflow or not.

If you do not want to merge this PR, feel free to close it and deal with the problem yourselves.

More context and feedback: http://b/406537467
