### PR TITLE
fix:  generate action not working

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -34,7 +34,7 @@ jobs:
           path: discovery-artifact-manager
       - run: |
           sudo apt update
-          sudo install python3
+          sudo apt install python3
           python3 --version
           pip --version  
       - run: ./google-api-java-client-services/.github/workflows/generate.sh ${{ matrix.service }}

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -15,7 +15,7 @@ on:
 name: generate
 jobs:
   generate_one:
-    runs-on: 'ubuntu-24.04'
+    runs-on: 'ubuntu-20.04'
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -32,9 +32,11 @@ jobs:
           repository: googleapis/discovery-artifact-manager
           fetch-depth: 1
           path: discovery-artifact-manager
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.8.10
       - run: |
           sudo apt update
-          sudo apt install python3
           python3 --version
           pip install pip==21.3.1
           pip --version  

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -33,8 +33,8 @@ jobs:
           fetch-depth: 1
           path: discovery-artifact-manager
       - uses: actions/setup-python@v5
-          with:
-            python-version: 3.6
+        with:
+          python-version: 3.6
       - run: |
           sudo apt update
           python3 --version

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -32,11 +32,13 @@ jobs:
           repository: googleapis/discovery-artifact-manager
           fetch-depth: 1
           path: discovery-artifact-manager
+      - uses: actions/setup-python@v5
+          with:
+            python-version: 3.6
       - run: |
           sudo apt update
-          sudo apt install python3
-          echo "using $(python3 --version)"
-          echo "using $(pip --version)"  
+          python3 --version
+          pip --version  
       - run: ./google-api-java-client-services/.github/workflows/generate.sh ${{ matrix.service }}
       - uses: googleapis/code-suggester@v2 # takes the changes from git directory
         env:

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -36,8 +36,7 @@ jobs:
           sudo apt update
           sudo apt install python3
           echo "using $(python3 --version)"
-          curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip.py
-          python3 get-pip.py
+          echo "using $(pip --version)"  
       - run: ./google-api-java-client-services/.github/workflows/generate.sh ${{ matrix.service }}
       - uses: googleapis/code-suggester@v2 # takes the changes from git directory
         env:

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -15,7 +15,7 @@ on:
 name: generate
 jobs:
   generate_one:
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-24.04'
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -15,7 +15,7 @@ on:
 name: generate
 jobs:
   generate_one:
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-22.04'
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -34,7 +34,7 @@ jobs:
           path: discovery-artifact-manager
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8.10
+          python-version: 3.8.18
       - run: |
           sudo apt update
           python3 --version

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -32,11 +32,9 @@ jobs:
           repository: googleapis/discovery-artifact-manager
           fetch-depth: 1
           path: discovery-artifact-manager
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.6
       - run: |
           sudo apt update
+          sudo install python3
           python3 --version
           pip --version  
       - run: ./google-api-java-client-services/.github/workflows/generate.sh ${{ matrix.service }}

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -36,6 +36,7 @@ jobs:
           sudo apt update
           sudo apt install python3
           python3 --version
+          pip install pip==21.3.1
           pip --version  
       - run: ./google-api-java-client-services/.github/workflows/generate.sh ${{ matrix.service }}
       - uses: googleapis/code-suggester@v2 # takes the changes from git directory


### PR DESCRIPTION
As python gets updated, it will no longer work with the version of pip we need to use 'django.utils.six.moves'.

so lock in python + pip for now.  ideally we would move away from djiango 

tested [here](https://github.com/googleapis/google-api-java-client-services/actions/runs/14539912149)