### PR TITLE
build(deps): maven-gpg-plugin 3.2.7 in the generator

### DIFF
--- a/generator/src/googleapis/codegen/languages/java/1.26.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.26.0/templates/_pom_xml.tmpl
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/generator/src/googleapis/codegen/languages/java/1.27.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.27.0/templates/_pom_xml.tmpl
@@ -129,7 +129,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/generator/src/googleapis/codegen/languages/java/1.28.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.28.0/templates/_pom_xml.tmpl
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/generator/src/googleapis/codegen/languages/java/1.29.2/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.29.2/templates/_pom_xml.tmpl
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/generator/src/googleapis/codegen/languages/java/1.30.1/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.30.1/templates/_pom_xml.tmpl
@@ -144,7 +144,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/generator/src/googleapis/codegen/languages/java/1.31.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.31.0/templates/_pom_xml.tmpl
@@ -144,7 +144,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/generator/src/googleapis/codegen/languages/java/2.0.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/2.0.0/templates/_pom_xml.tmpl
@@ -144,7 +144,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/generator/src/googleapis/codegen/languages/java/default/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/default/templates/_pom_xml.tmpl
@@ -145,7 +145,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
Let's use the latest maven-gpg-plugin in the generator. It seems that there's a concurrency problem in the old versions.

b/421886950

This version matches what we have in https://github.com/googleapis/java-shared-config/blob/main/native-image-shared-config/pom.xml#L190C17-L200C32.

I'll create another CL that modify the generated pom.xml files.
