### PR TITLE
chore: update maven-gpg-plugin to 3.2.7

### DIFF
--- a/clients/google-api-services-backupdr/v1/2.0.0/pom.xml
+++ b/clients/google-api-services-backupdr/v1/2.0.0/pom.xml
@@ -147,7 +147,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/clients/google-api-services-compute/alpha/2.0.0/pom.xml
+++ b/clients/google-api-services-compute/alpha/2.0.0/pom.xml
@@ -147,7 +147,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/clients/google-api-services-compute/beta/2.0.0/pom.xml
+++ b/clients/google-api-services-compute/beta/2.0.0/pom.xml
@@ -147,7 +147,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/clients/google-api-services-compute/v1/2.0.0/pom.xml
+++ b/clients/google-api-services-compute/v1/2.0.0/pom.xml
@@ -147,7 +147,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/clients/google-api-services-contactcenterinsights/v1/2.0.0/pom.xml
+++ b/clients/google-api-services-contactcenterinsights/v1/2.0.0/pom.xml
@@ -147,7 +147,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/clients/google-api-services-datalineage/v1/2.0.0/pom.xml
+++ b/clients/google-api-services-datalineage/v1/2.0.0/pom.xml
@@ -147,7 +147,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/clients/google-api-services-dialogflow/v2/2.0.0/pom.xml
+++ b/clients/google-api-services-dialogflow/v2/2.0.0/pom.xml
@@ -147,7 +147,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/clients/google-api-services-dialogflow/v2beta1/2.0.0/pom.xml
+++ b/clients/google-api-services-dialogflow/v2beta1/2.0.0/pom.xml
@@ -147,7 +147,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/clients/google-api-services-dialogflow/v3/2.0.0/pom.xml
+++ b/clients/google-api-services-dialogflow/v3/2.0.0/pom.xml
@@ -147,7 +147,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/clients/google-api-services-dialogflow/v3beta1/2.0.0/pom.xml
+++ b/clients/google-api-services-dialogflow/v3beta1/2.0.0/pom.xml
@@ -147,7 +147,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/clients/google-api-services-identitytoolkit/v1/2.0.0/pom.xml
+++ b/clients/google-api-services-identitytoolkit/v1/2.0.0/pom.xml
@@ -147,7 +147,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/clients/google-api-services-identitytoolkit/v2/2.0.0/pom.xml
+++ b/clients/google-api-services-identitytoolkit/v2/2.0.0/pom.xml
@@ -147,7 +147,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/clients/google-api-services-identitytoolkit/v3/2.0.0/pom.xml
+++ b/clients/google-api-services-identitytoolkit/v3/2.0.0/pom.xml
@@ -147,7 +147,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/clients/google-api-services-integrations/v1/2.0.0/pom.xml
+++ b/clients/google-api-services-integrations/v1/2.0.0/pom.xml
@@ -147,7 +147,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/clients/google-api-services-integrations/v1alpha/2.0.0/pom.xml
+++ b/clients/google-api-services-integrations/v1alpha/2.0.0/pom.xml
@@ -147,7 +147,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
The updates for these modules are currently blocked on compilation issues on the regeneration PRs (example, https://github.com/googleapis/google-api-java-client-services/pull/27013) so updating these manually.