### PR TITLE
chore: profile to avoid using nexus-staging-maven-plugin

### DIFF
--- a/generator/src/googleapis/codegen/languages/java/1.26.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.26.0/templates/_pom_xml.tmpl
@@ -45,17 +45,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.5</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>2.2.1</version>
@@ -116,6 +105,55 @@
   </properties>
 
   <profiles>
+      <profile>
+            <!-- By default, we release artifacts to Sonatype, which requires
+                nexus-staging-maven-plugin. -->
+            <id>release-sonatype</id>
+            <activation>
+              <property>
+                <!-- Only when we use the release-gcp-artifact-registry profile,
+                which comes with artifact-registry-url property, this profile is
+                turned off. -->
+                <name>!artifact-registry-url</name>
+              </property>
+            </activation>
+            <build>
+              <plugins>
+                <plugin>
+                  <groupId>org.sonatype.plugins</groupId>
+                  <artifactId>nexus-staging-maven-plugin</artifactId>
+                  <version>1.6.13</version>
+                  <extensions>true</extensions>
+                  <configuration>
+                    <serverId>sonatype-nexus-staging</serverId>
+                    <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                  </configuration>
+                </plugin>
+              </plugins>
+            </build>
+      </profile>
+      <profile>
+            <!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+                this release-gcp-artifact-registry profile:
+                mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+                    -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+                -->
+            <id>release-gcp-artifact-registry</id>
+            <properties>
+              <artifact-registry-url>artifactregistry://please-define-artifact-registry-url-property</artifact-registry-url>
+            </properties>
+            <distributionManagement>
+              <repository>
+                <id>gcp-artifact-registry-repository</id>
+                <url>${artifact-registry-url}</url>
+              </repository>
+              <snapshotRepository>
+                <id>gcp-artifact-registry-repository</id>
+                <url>${artifact-registry-url}</url>
+              </snapshotRepository>
+            </distributionManagement>
+      </profile>
     <profile>
       <id>release-sign-artifacts</id>
       <activation>

--- a/generator/src/googleapis/codegen/languages/java/1.27.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.27.0/templates/_pom_xml.tmpl
@@ -45,17 +45,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.5</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>2.2.1</version>
@@ -116,6 +105,55 @@
   </properties>
 
   <profiles>
+      <profile>
+            <!-- By default, we release artifacts to Sonatype, which requires
+                nexus-staging-maven-plugin. -->
+            <id>release-sonatype</id>
+            <activation>
+              <property>
+                <!-- Only when we use the release-gcp-artifact-registry profile,
+                which comes with artifact-registry-url property, this profile is
+                turned off. -->
+                <name>!artifact-registry-url</name>
+              </property>
+            </activation>
+            <build>
+              <plugins>
+                <plugin>
+                  <groupId>org.sonatype.plugins</groupId>
+                  <artifactId>nexus-staging-maven-plugin</artifactId>
+                  <version>1.6.13</version>
+                  <extensions>true</extensions>
+                  <configuration>
+                    <serverId>sonatype-nexus-staging</serverId>
+                    <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                  </configuration>
+                </plugin>
+              </plugins>
+            </build>
+      </profile>
+      <profile>
+            <!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+                this release-gcp-artifact-registry profile:
+                mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+                    -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+                -->
+            <id>release-gcp-artifact-registry</id>
+            <properties>
+              <artifact-registry-url>artifactregistry://please-define-artifact-registry-url-property</artifact-registry-url>
+            </properties>
+            <distributionManagement>
+              <repository>
+                <id>gcp-artifact-registry-repository</id>
+                <url>${artifact-registry-url}</url>
+              </repository>
+              <snapshotRepository>
+                <id>gcp-artifact-registry-repository</id>
+                <url>${artifact-registry-url}</url>
+              </snapshotRepository>
+            </distributionManagement>
+      </profile>
     <profile>
       <id>release-sign-artifacts</id>
       <activation>

--- a/generator/src/googleapis/codegen/languages/java/1.28.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.28.0/templates/_pom_xml.tmpl
@@ -45,17 +45,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.5</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>2.2.1</version>
@@ -115,6 +104,55 @@
   </properties>
 
   <profiles>
+      <profile>
+            <!-- By default, we release artifacts to Sonatype, which requires
+                nexus-staging-maven-plugin. -->
+            <id>release-sonatype</id>
+            <activation>
+              <property>
+                <!-- Only when we use the release-gcp-artifact-registry profile,
+                which comes with artifact-registry-url property, this profile is
+                turned off. -->
+                <name>!artifact-registry-url</name>
+              </property>
+            </activation>
+            <build>
+              <plugins>
+                <plugin>
+                  <groupId>org.sonatype.plugins</groupId>
+                  <artifactId>nexus-staging-maven-plugin</artifactId>
+                  <version>1.6.13</version>
+                  <extensions>true</extensions>
+                  <configuration>
+                    <serverId>sonatype-nexus-staging</serverId>
+                    <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                  </configuration>
+                </plugin>
+              </plugins>
+            </build>
+      </profile>
+      <profile>
+            <!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+                this release-gcp-artifact-registry profile:
+                mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+                    -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+                -->
+            <id>release-gcp-artifact-registry</id>
+            <properties>
+              <artifact-registry-url>artifactregistry://please-define-artifact-registry-url-property</artifact-registry-url>
+            </properties>
+            <distributionManagement>
+              <repository>
+                <id>gcp-artifact-registry-repository</id>
+                <url>${artifact-registry-url}</url>
+              </repository>
+              <snapshotRepository>
+                <id>gcp-artifact-registry-repository</id>
+                <url>${artifact-registry-url}</url>
+              </snapshotRepository>
+            </distributionManagement>
+      </profile>
     <profile>
       <id>release-sign-artifacts</id>
       <activation>

--- a/generator/src/googleapis/codegen/languages/java/1.29.2/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.29.2/templates/_pom_xml.tmpl
@@ -45,17 +45,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.5</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>2.2.1</version>
@@ -115,6 +104,55 @@
   </properties>
 
   <profiles>
+    <profile>
+            <!-- By default, we release artifacts to Sonatype, which requires
+                nexus-staging-maven-plugin. -->
+            <id>release-sonatype</id>
+            <activation>
+              <property>
+                <!-- Only when we use the release-gcp-artifact-registry profile,
+                which comes with artifact-registry-url property, this profile is
+                turned off. -->
+                <name>!artifact-registry-url</name>
+              </property>
+            </activation>
+            <build>
+              <plugins>
+                <plugin>
+                  <groupId>org.sonatype.plugins</groupId>
+                  <artifactId>nexus-staging-maven-plugin</artifactId>
+                  <version>1.6.13</version>
+                  <extensions>true</extensions>
+                  <configuration>
+                    <serverId>sonatype-nexus-staging</serverId>
+                    <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                  </configuration>
+                </plugin>
+              </plugins>
+            </build>
+    </profile>
+    <profile>
+            <!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+                this release-gcp-artifact-registry profile:
+                mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+                    -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+                -->
+            <id>release-gcp-artifact-registry</id>
+            <properties>
+              <artifact-registry-url>artifactregistry://please-define-artifact-registry-url-property</artifact-registry-url>
+            </properties>
+            <distributionManagement>
+              <repository>
+                <id>gcp-artifact-registry-repository</id>
+                <url>${artifact-registry-url}</url>
+              </repository>
+              <snapshotRepository>
+                <id>gcp-artifact-registry-repository</id>
+                <url>${artifact-registry-url}</url>
+              </snapshotRepository>
+            </distributionManagement>
+    </profile>
     <profile>
       <id>release-sign-artifacts</id>
       <activation>

--- a/generator/src/googleapis/codegen/languages/java/1.30.1/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.30.1/templates/_pom_xml.tmpl
@@ -45,17 +45,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.5</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>2.2.1</version>
@@ -131,6 +120,55 @@
   </properties>
 
   <profiles>
+     <profile>
+           <!-- By default, we release artifacts to Sonatype, which requires
+               nexus-staging-maven-plugin. -->
+           <id>release-sonatype</id>
+           <activation>
+             <property>
+               <!-- Only when we use the release-gcp-artifact-registry profile,
+               which comes with artifact-registry-url property, this profile is
+               turned off. -->
+               <name>!artifact-registry-url</name>
+             </property>
+           </activation>
+           <build>
+             <plugins>
+               <plugin>
+                 <groupId>org.sonatype.plugins</groupId>
+                 <artifactId>nexus-staging-maven-plugin</artifactId>
+                 <version>1.6.13</version>
+                 <extensions>true</extensions>
+                 <configuration>
+                   <serverId>sonatype-nexus-staging</serverId>
+                   <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
+                   <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                 </configuration>
+               </plugin>
+             </plugins>
+           </build>
+     </profile>
+     <profile>
+           <!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+               this release-gcp-artifact-registry profile:
+               mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+                   -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+               -->
+           <id>release-gcp-artifact-registry</id>
+           <properties>
+             <artifact-registry-url>artifactregistry://please-define-artifact-registry-url-property</artifact-registry-url>
+           </properties>
+           <distributionManagement>
+             <repository>
+               <id>gcp-artifact-registry-repository</id>
+               <url>${artifact-registry-url}</url>
+             </repository>
+             <snapshotRepository>
+               <id>gcp-artifact-registry-repository</id>
+               <url>${artifact-registry-url}</url>
+             </snapshotRepository>
+           </distributionManagement>
+    </profile>
     <profile>
       <id>release-sign-artifacts</id>
       <activation>

--- a/generator/src/googleapis/codegen/languages/java/1.31.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.31.0/templates/_pom_xml.tmpl
@@ -45,17 +45,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>2.4</version>
@@ -131,6 +120,55 @@
   </properties>
 
   <profiles>
+     <profile>
+            <!-- By default, we release artifacts to Sonatype, which requires
+                nexus-staging-maven-plugin. -->
+            <id>release-sonatype</id>
+            <activation>
+              <property>
+                <!-- Only when we use the release-gcp-artifact-registry profile,
+                which comes with artifact-registry-url property, this profile is
+                turned off. -->
+                <name>!artifact-registry-url</name>
+              </property>
+            </activation>
+            <build>
+              <plugins>
+                <plugin>
+                  <groupId>org.sonatype.plugins</groupId>
+                  <artifactId>nexus-staging-maven-plugin</artifactId>
+                  <version>1.6.13</version>
+                  <extensions>true</extensions>
+                  <configuration>
+                    <serverId>sonatype-nexus-staging</serverId>
+                    <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                  </configuration>
+                </plugin>
+              </plugins>
+            </build>
+     </profile>
+     <profile>
+            <!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+                this release-gcp-artifact-registry profile:
+                mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+                    -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+                -->
+            <id>release-gcp-artifact-registry</id>
+            <properties>
+              <artifact-registry-url>artifactregistry://please-define-artifact-registry-url-property</artifact-registry-url>
+            </properties>
+            <distributionManagement>
+              <repository>
+                <id>gcp-artifact-registry-repository</id>
+                <url>${artifact-registry-url}</url>
+              </repository>
+              <snapshotRepository>
+                <id>gcp-artifact-registry-repository</id>
+                <url>${artifact-registry-url}</url>
+              </snapshotRepository>
+            </distributionManagement>
+    </profile>
     <profile>
       <id>release-sign-artifacts</id>
       <activation>

--- a/generator/src/googleapis/codegen/languages/java/2.0.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/2.0.0/templates/_pom_xml.tmpl
@@ -45,17 +45,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>2.4</version>
@@ -131,6 +120,55 @@
   </properties>
 
   <profiles>
+    <profile>
+          <!-- By default, we release artifacts to Sonatype, which requires
+              nexus-staging-maven-plugin. -->
+          <id>release-sonatype</id>
+          <activation>
+            <property>
+              <!-- Only when we use the release-gcp-artifact-registry profile,
+              which comes with artifact-registry-url property, this profile is
+              turned off. -->
+              <name>!artifact-registry-url</name>
+            </property>
+          </activation>
+          <build>
+            <plugins>
+              <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.13</version>
+                <extensions>true</extensions>
+                <configuration>
+                  <serverId>sonatype-nexus-staging</serverId>
+                  <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
+                  <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                </configuration>
+              </plugin>
+            </plugins>
+          </build>
+    </profile>
+    <profile>
+          <!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+              this release-gcp-artifact-registry profile:
+              mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+                  -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+              -->
+          <id>release-gcp-artifact-registry</id>
+          <properties>
+            <artifact-registry-url>artifactregistry://please-define-artifact-registry-url-property</artifact-registry-url>
+          </properties>
+          <distributionManagement>
+            <repository>
+              <id>gcp-artifact-registry-repository</id>
+              <url>${artifact-registry-url}</url>
+            </repository>
+            <snapshotRepository>
+              <id>gcp-artifact-registry-repository</id>
+              <url>${artifact-registry-url}</url>
+            </snapshotRepository>
+          </distributionManagement>
+    </profile>
     <profile>
       <id>release-sign-artifacts</id>
       <activation>


### PR DESCRIPTION
This PR includes:
- A profile to avoid using nexus-staging-maven-plugin.
- A profile to upload to GCP Artifact Registry.

Following https://github.com/googleapis/google-oauth-java-client/pull/1132