### PR TITLE
chore: add developer info to pom templates

### DIFF
--- a/generator/src/googleapis/codegen/languages/java/1.26.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.26.0/templates/_pom_xml.tmpl
@@ -14,6 +14,16 @@
 
   <inceptionYear>2011</inceptionYear>
 
+  <developers>
+    <developer>
+      <id>GoogleAPIs</id>
+      <name>GoogleAPIs</name>
+      <email>googleapis@googlegroups.com</email>
+      <organization>{{ api.ownerName }}</organization>{% if api.ownerDomain == "google.com" %}
+      <organizationUrl>https://www.google.com</organizationUrl>{% endif %}
+    </developer>
+  </developers>
+
   <organization>
     <name>{{ api.ownerName }}</name>{% if api.ownerDomain == "google.com" %}
     <url>http://www.google.com/</url>{% endif %}

--- a/generator/src/googleapis/codegen/languages/java/1.27.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.27.0/templates/_pom_xml.tmpl
@@ -14,6 +14,16 @@
 
   <inceptionYear>2011</inceptionYear>
 
+  <developers>
+    <developer>
+      <id>GoogleAPIs</id>
+      <name>GoogleAPIs</name>
+      <email>googleapis@googlegroups.com</email>
+      <organization>{{ api.ownerName }}</organization>{% if api.ownerDomain == "google.com" %}
+      <organizationUrl>https://www.google.com</organizationUrl>{% endif %}
+    </developer>
+  </developers>
+
   <organization>
     <name>{{ api.ownerName }}</name>{% if api.ownerDomain == "google.com" %}
     <url>http://www.google.com/</url>{% endif %}

--- a/generator/src/googleapis/codegen/languages/java/1.28.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.28.0/templates/_pom_xml.tmpl
@@ -14,6 +14,16 @@
 
   <inceptionYear>2011</inceptionYear>
 
+  <developers>
+    <developer>
+      <id>GoogleAPIs</id>
+      <name>GoogleAPIs</name>
+      <email>googleapis@googlegroups.com</email>
+      <organization>{{ api.ownerName }}</organization>{% if api.ownerDomain == "google.com" %}
+      <organizationUrl>https://www.google.com</organizationUrl>{% endif %}
+    </developer>
+  </developers>
+
   <organization>
     <name>{{ api.ownerName }}</name>{% if api.ownerDomain == "google.com" %}
     <url>http://www.google.com/</url>{% endif %}

--- a/generator/src/googleapis/codegen/languages/java/1.29.2/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.29.2/templates/_pom_xml.tmpl
@@ -14,6 +14,16 @@
 
   <inceptionYear>2011</inceptionYear>
 
+  <developers>
+    <developer>
+      <id>GoogleAPIs</id>
+      <name>GoogleAPIs</name>
+      <email>googleapis@googlegroups.com</email>
+      <organization>{{ api.ownerName }}</organization>{% if api.ownerDomain == "google.com" %}
+      <organizationUrl>https://www.google.com</organizationUrl>{% endif %}
+    </developer>
+  </developers>
+
   <organization>
     <name>{{ api.ownerName }}</name>{% if api.ownerDomain == "google.com" %}
     <url>http://www.google.com/</url>{% endif %}

--- a/generator/src/googleapis/codegen/languages/java/1.30.1/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.30.1/templates/_pom_xml.tmpl
@@ -14,6 +14,16 @@
 
   <inceptionYear>2011</inceptionYear>
 
+  <developers>
+    <developer>
+      <id>GoogleAPIs</id>
+      <name>GoogleAPIs</name>
+      <email>googleapis@googlegroups.com</email>
+      <organization>{{ api.ownerName }}</organization>{% if api.ownerDomain == "google.com" %}
+      <organizationUrl>https://www.google.com</organizationUrl>{% endif %}
+    </developer>
+  </developers>
+
   <organization>
     <name>{{ api.ownerName }}</name>{% if api.ownerDomain == "google.com" %}
     <url>http://www.google.com/</url>{% endif %}

--- a/generator/src/googleapis/codegen/languages/java/1.31.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/1.31.0/templates/_pom_xml.tmpl
@@ -14,6 +14,16 @@
 
   <inceptionYear>2011</inceptionYear>
 
+  <developers>
+    <developer>
+      <id>GoogleAPIs</id>
+      <name>GoogleAPIs</name>
+      <email>googleapis@googlegroups.com</email>
+      <organization>{{ api.ownerName }}</organization>{% if api.ownerDomain == "google.com" %}
+      <organizationUrl>https://www.google.com</organizationUrl>{% endif %}
+    </developer>
+  </developers>
+
   <organization>
     <name>{{ api.ownerName }}</name>{% if api.ownerDomain == "google.com" %}
     <url>http://www.google.com/</url>{% endif %}

--- a/generator/src/googleapis/codegen/languages/java/2.0.0/templates/_pom_xml.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/2.0.0/templates/_pom_xml.tmpl
@@ -14,6 +14,16 @@
 
   <inceptionYear>2011</inceptionYear>
 
+  <developers>
+    <developer>
+      <id>GoogleAPIs</id>
+      <name>GoogleAPIs</name>
+      <email>googleapis@googlegroups.com</email>
+      <organization>{{ api.ownerName }}</organization>{% if api.ownerDomain == "google.com" %}
+      <organizationUrl>https://www.google.com</organizationUrl>{% endif %}
+    </developer>
+  </developers>
+
   <organization>
     <name>{{ api.ownerName }}</name>{% if api.ownerDomain == "google.com" %}
     <url>http://www.google.com/</url>{% endif %}


### PR DESCRIPTION
To address the following issue with the release:
```
"errors":{"pkg:maven/com.google.apis/google-api-services-alloydb@v1-rev20250605-2.0.0":["Namespace 'com.google.apis' is not allowed","Developers information is missing"]}}
```
Context: https://central.sonatype.org/publish/requirements/#developer-information

The developer id information is the same as https://github.com/googleapis/sdk-platform-java/blob/71da6c077d745d4c248eb122fcf9920ee0df772f/gax-java/pom.xml#L18-L26

This change has been verified with v1 alloydb in https://github.com/googleapis/google-api-java-client-services/pull/27633.
