### PR TITLE
chore: remove unused versions from features.json

### DIFF
--- a/generator/src/googleapis/codegen/languages/java/2.0.0/features.json
+++ b/generator/src/googleapis/codegen/languages/java/2.0.0/features.json
@@ -4,16 +4,6 @@
   "generator": "java1_15",
   "releaseVersion": "2.0.0",
   "baseClientLibrary": "2.7.2",
-  "oauthClientLibrary": "1.39.0",
-  "gsonVersion": "2.11.0",
-  "httpClientLibrary": "1.47.1",
-  "httpClientVersion": "4.5.14",
-  "jackson2CoreVersion": "2.19.0",
-  "jdo2ApiVersion": "2.3-eb",
-  "jettyVersion": "6.1.26",
-  "jettyUtilVersion": "6.1.26",
-  "jsr305Version": "3.0.2",
-  "transactionApiVersion": "1.1",
   "descriptor_additions": {
     "proguard-config": "proguard-google-api-client.txt",
     "files": [


### PR DESCRIPTION
the "default" template is not used, only 2.0.0 is