### PR TITLE
ci(codegen): add input for batch index in codegen workflow

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -7,7 +7,7 @@ on:
     inputs:
       batch_index:
         type: number
-        description: Index of the batch ([0-2])
+        description: Index of the batch ([0-2]). You must call this workflow one time per index in order to confirm the generation in all the jobs.
 
 name: codegen
 jobs:


### PR DESCRIPTION
This allows to be manually called by specifying the batch index

Confirmed in https://github.com/googleapis/google-api-java-client-services/actions/runs/17165225545