### PR TITLE
chore: Manually bump storage version to v1-rev20250815-2.0.0

### DIFF
--- a/clients/google-api-services-storage/v1/2.0.0/README.md
+++ b/clients/google-api-services-storage/v1/2.0.0/README.md
@@ -22,7 +22,7 @@ Add the following lines to your `pom.xml` file:
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-storage</artifactId>
-      <version>v1-rev20250814-2.0.0</version>
+      <version>v1-rev20250815-2.0.0</version>
     </dependency>
   </dependencies>
 </project>
@@ -35,7 +35,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  implementation 'com.google.apis:google-api-services-storage:v1-rev20250814-2.0.0'
+  implementation 'com.google.apis:google-api-services-storage:v1-rev20250815-2.0.0'
 }
 ```
 

--- a/clients/google-api-services-storage/v1/2.0.0/pom.xml
+++ b/clients/google-api-services-storage/v1/2.0.0/pom.xml
@@ -8,8 +8,8 @@
 
   <groupId>com.google.apis</groupId>
   <artifactId>google-api-services-storage</artifactId>
-  <version>v1-rev20250814-2.0.0</version>
-  <name>Cloud Storage JSON API v1-rev20250814-2.0.0</name>
+  <version>v1-rev20250815-2.0.0</version>
+  <name>Cloud Storage JSON API v1-rev20250815-2.0.0</name>
   <packaging>jar</packaging>
 
   <inceptionYear>2011</inceptionYear>

--- a/clients/google-api-services-storage/v1/README.md
+++ b/clients/google-api-services-storage/v1/README.md
@@ -22,7 +22,7 @@ Add the following lines to your `pom.xml` file:
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-storage</artifactId>
-      <version>v1-rev20250814-2.0.0</version>
+      <version>v1-rev20250815-2.0.0</version>
     </dependency>
   </dependencies>
 </project>
@@ -35,7 +35,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  implementation 'com.google.apis:google-api-services-storage:v1-rev20250814-2.0.0'
+  implementation 'com.google.apis:google-api-services-storage:v1-rev20250815-2.0.0'
 }
 ```
 


### PR DESCRIPTION
The existing storage version v1-rev20250814-2.0.0 has google-api-client v2.8.1. The downgraded google-api-client version didn't trigger an update to the versionId and isn't released to Maven Central:

https://central.sonatype.com/artifact/com.google.apis/google-api-services-storage/v1-rev20250814-2.0.0