### PR TITLE
minor: Fixed 404 google-api-services-admin/directory_v1 link in README.md

### DIFF
--- a/clients/google-api-services-admin/directory_v1/README.md
+++ b/clients/google-api-services-admin/directory_v1/README.md
@@ -39,6 +39,6 @@ dependencies {
 }
 ```
 
-[javadoc]: https://googleapis.dev/java/google-api-services-admin-directory/latest/index.html
+[javadoc]: https://javadoc.io/doc/com.google.apis/google-api-services-admin-directory/latest/index.html
 [google-api-client]: https://github.com/googleapis/google-api-java-client/
 [api-explorer]: https://developers.google.com/apis-explorer/#p/admin/v1/


### PR DESCRIPTION
Fixes [#29581](https://github.com/googleapis/google-api-java-client-services/issues/29581)

Old link yields 404, updated with a public JavaDoc link, please advice if this needs another link