### PR TITLE
docs: Use correct Javadoc link in README template

### DIFF
--- a/generator/src/googleapis/codegen/languages/java/2.0.0/templates/README.md.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/2.0.0/templates/README.md.tmpl
@@ -39,6 +39,6 @@ dependencies {
 }
 ```
 
-[javadoc]: https://googleapis.dev/java/{{ api.maven.artifact_id }}/latest/index.html
+[javadoc]: https://javadoc.io/doc/com.google.apis/{{ api.maven.artifact_id }}/latest/index.html
 [google-api-client]: https://github.com/googleapis/google-api-java-client/
 [api-explorer]: https://developers.google.com/apis-explorer/#p/{{ api.name }}/v1/


### PR DESCRIPTION
Borrows from https://github.com/googleapis/google-api-java-client-services/pull/30334

Fixes https://github.com/googleapis/google-api-java-client-services/issues/29581