### PR TITLE
chore: update generated javadocs to recommend using NetHttpTransport

### DIFF
--- a/generator/src/googleapis/codegen/languages/java/2.0.0/templates/___package___/___api_className___.java.tmpl
+++ b/generator/src/googleapis/codegen/languages/java/2.0.0/templates/___package___/___api_className___.java.tmpl
@@ -90,7 +90,7 @@ public class {{ api.className }} extends com.google.api.client.googleapis.servic
    *        {@code com.google.api.client.extensions.appengine.http.UrlFetchTransport}</li>
    *        <li>Android: {@code newCompatibleTransport} from
    *        {@code com.google.api.client.extensions.android.http.AndroidHttp}</li>
-   *        <li>Java: {@link com.google.api.client.googleapis.javanet.GoogleNetHttpTransport#newTrustedTransport()}
+   *        <li>Java: {@code com.google.api.client.http.javanet.NetHttpTransport}</li>
    *        </li>
    *        </ul>
    * @param jsonFactory JSON factory, which may be:
@@ -159,8 +159,7 @@ public class {{ api.className }} extends com.google.api.client.googleapis.servic
      *        {@code com.google.api.client.extensions.appengine.http.UrlFetchTransport}</li>
      *        <li>Android: {@code newCompatibleTransport} from
      *        {@code com.google.api.client.extensions.android.http.AndroidHttp}</li>
-     *        <li>Java: {@link com.google.api.client.googleapis.javanet.GoogleNetHttpTransport#newTrustedTransport()}
-     *        </li>
+     *        <li>Java: {@code com.google.api.client.http.javanet.NetHttpTransport}</li>
      *        </ul>
      * @param jsonFactory JSON factory, which may be:
      *        <ul>


### PR DESCRIPTION
We are in the process of deprecating GoogleNetHttpTransport.  Updating javadocs to recommend NetHttpTransport.

Ran generator and validated that java docs were appropriately updated.