### PR TITLE
build: checkout and push instead of direct calls to GitHub API

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -56,12 +56,12 @@ jobs:
             }
             return result
   generate:
-    uses: googleapis/google-api-java-client-services/.github/workflows/generate.yaml@build/fix-compute
+    uses: googleapis/google-api-java-client-services/.github/workflows/generate.yaml@main
     needs: batch
     secrets: inherit
     # The size of the batch is implicitly decided by the hour of the day.
     # For example, a job starting at "1:30" uses the chunk at the index 1 in the array.
-    if: github.event_name != 'workflow_dispatch' && ${{!!fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour]}}
+    if: ${{ github.event_name != 'workflow_dispatch' && !!fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour] }}
     with: 
       services: ${{toJson(fromJson(needs.batch.outputs.services).batches[fromJson(needs.batch.outputs.services).hour])}}
   generate_dispatch:

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -56,7 +56,7 @@ jobs:
             }
             return result
   generate:
-    uses: googleapis/google-api-java-client-services/.github/workflows/generate.yaml@main
+    uses: googleapis/google-api-java-client-services/.github/workflows/generate.yaml@build/fix-compute
     needs: batch
     secrets: inherit
     # The size of the batch is implicitly decided by the hour of the day.

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -27,13 +27,13 @@ jobs:
         with:
           fetch-depth: 1
           path: google-api-java-client-services
-          token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
       - uses: actions/checkout@v2
         with:
           repository: googleapis/discovery-artifact-manager
           fetch-depth: 1
           path: discovery-artifact-manager
-          token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
       - uses: actions/setup-python@v5
         with:
           python-version: 3.8.18
@@ -47,16 +47,19 @@ jobs:
         shell: bash
         working-directory: google-api-java-client-services
         env:
-          GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
           SERVICE: ${{ matrix.service }}
-          AUTHOR: "Cloud Java Bot <cloud-java-bot@google.com>"
+          AUTHOR: "yoshi-code-bot <yoshi-code-bot@google.com>"
           BASE_REPO: "${{ github.repository }}"
         run: |
           set -ex
 
           # 1. Setup Identity
-          git config user.name "Cloud Java Bot"
-          git config user.email "cloud-java-bot@google.com"
+          git config user.name "yoshi-code-bot"
+          git config user.email "yoshi-code-bot@google.com"
+          
+          # 2. Setup Remote Fork
+          git remote add fork "https://yoshi-code-bot:${GH_TOKEN}@github.com/yoshi-code-bot/google-api-java-client-services.git"
           
           # 3. Create Branch
           BRANCH="regenerate-${SERVICE}"
@@ -74,11 +77,11 @@ jobs:
           fi
 
           git commit -m "$MESSAGE"
-          git push origin "$BRANCH" --force
+          git push fork "$BRANCH" --force
           
           gh pr create \
             --repo "$BASE_REPO" \
-            --head "${BRANCH}" \
+            --head "yoshi-code-bot:${BRANCH}" \
             --base "main" \
             --title "$MESSAGE" \
             --body "Generated in GitHub action: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -43,6 +43,7 @@ jobs:
       - run: ./google-api-java-client-services/.github/workflows/generate.sh ${{ matrix.service }}
       - name: Create PR via Local Checkout (Large Commit Support)
         shell: bash
+        working-directory: google-api-java-client-services
         env:
           GH_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
           SERVICE: ${{ matrix.service }}
@@ -50,6 +51,8 @@ jobs:
           FORK_REPO: "yoshi-code-bot/google-api-java-client-services"
           BASE_REPO: "${{ github.repository }}"
         run: |
+          set -ex
+
           # 1. Setup Identity
           git config user.name "Yoshi Code Bot"
           git config user.email "yoshi-automation@google.com"

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -41,19 +41,48 @@ jobs:
           pip install pip==21.3.1
           pip --version  
       - run: ./google-api-java-client-services/.github/workflows/generate.sh ${{ matrix.service }}
-      - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
+      - name: Create PR via Local Checkout (Large Commit Support)
+        shell: bash
         env:
-          MESSAGE: 'chore: regenerate ${{ matrix.service }} client'
-          AUTHOR: Yoshi Code Bot <yoshi-automation@google.com>
-        with: 
-          token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-          commit-message: ${{ env.MESSAGE }}
-          committer: ${{ env.AUTHOR }}
-          author: ${{ env.AUTHOR }}
-          branch: regenerate-${{ matrix.service }}
-          title: ${{ env.MESSAGE }}
-          body: 'Generated in GitHub action: https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/workflows/codegen.yaml'
-          add-paths: 'google-api-java-client-services/clients/google-api-services-${{ matrix.service }}'
-          base: main
-          push-to-fork: yoshi-code-bot/google-api-java-client-services
-        
+          GH_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+          SERVICE: ${{ matrix.service }}
+          AUTHOR: "Yoshi Code Bot <yoshi-automation@google.com>"
+          FORK_REPO: "yoshi-code-bot/google-api-java-client-services"
+          BASE_REPO: "${{ github.repository }}"
+        run: |
+          # 1. Setup Identity
+          git config user.name "Yoshi Code Bot"
+          git config user.email "yoshi-automation@google.com"
+
+          # 2. Add and Fetch Fork
+          git remote add fork "https://x-access-token:${GH_TOKEN}@github.com/${FORK_REPO}.git"
+          
+          # 3. Create Branch
+          BRANCH="regenerate-${SERVICE}"
+          git checkout -b "$BRANCH"
+
+          # 4. Stage specific files (Large commit handling)
+          TARGET_PATH="google-api-java-client-services/clients/google-api-services-${SERVICE}"
+          git add "$TARGET_PATH"
+
+          # 5. Commit & Push
+          MESSAGE="chore: regenerate ${SERVICE} client"
+          if git diff-index --quiet HEAD --; then
+            echo "No changes to commit for ${SERVICE}."
+            exit 0
+          fi
+
+          git commit -m "$MESSAGE"
+          git push fork "$BRANCH" --force
+
+          # 6. Create PR using GitHub CLI
+          # Note: --head needs 'owner:branch' format when pushing from a fork
+          FORK_OWNER=$(echo "$FORK_REPO" | cut -d'/' -f1)
+          
+          gh pr create \
+            --repo "$BASE_REPO" \
+            --head "${FORK_OWNER}:${BRANCH}" \
+            --base "main" \
+            --title "$MESSAGE" \
+            --body "Generated in GitHub action: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            || echo "PR already exists or failed to create, but changes are pushed."

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -27,13 +27,13 @@ jobs:
         with:
           fetch-depth: 1
           path: google-api-java-client-services
-          token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+          token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
       - uses: actions/checkout@v2
         with:
           repository: googleapis/discovery-artifact-manager
           fetch-depth: 1
           path: discovery-artifact-manager
-          token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+          token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
       - uses: actions/setup-python@v5
         with:
           python-version: 3.8.18
@@ -47,7 +47,7 @@ jobs:
         shell: bash
         working-directory: google-api-java-client-services
         env:
-          GH_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
           SERVICE: ${{ matrix.service }}
           AUTHOR: "Cloud Java Bot <cloud-java-bot@google.com>"
           BASE_REPO: "${{ github.repository }}"

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -41,18 +41,18 @@ jobs:
           pip install pip==21.3.1
           pip --version  
       - run: ./google-api-java-client-services/.github/workflows/generate.sh ${{ matrix.service }}
-      - uses: googleapis/code-suggester@v2 # takes the changes from git directory
+      - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
+        token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+        commit-message: ${{ env.MESSAGE }}
+        committer: ${{ env.AUTHOR }}
+        author: ${{ env.AUTHOR }}
+        branch: regenerate-${{ matrix.service }}
+        title: ${{ env.MESSAGE }}
+        body: 'Generated in GitHub action: https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/workflows/codegen.yaml'
+        add-paths: 'google-api-java-client-services/clients/google-api-services-${{ matrix.service }}'
+        base: main
+        push-to-fork: yoshi-code-bot/google-api-java-client-services
+
         env:
-          ACCESS_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-        with:
-          command: pr
-          upstream_owner: ${{ github.repository_owner }}
-          upstream_repo: google-api-java-client-services
-          description: 'Generated in GitHub action: https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/workflows/codegen.yaml'
-          title: 'chore: regenerate ${{ matrix.service }} client'
-          message: 'chore: regenerate ${{ matrix.service }} client'
-          branch: regenerate-${{ matrix.service }}
-          git_dir: 'google-api-java-client-services/clients/google-api-services-${{ matrix.service }}'
-          primary: main
-          force: true
-          fork: true
+          - MESSAGE: 'chore: regenerate ${{ matrix.service }} client'
+          - AUTHOR: Yoshi Code Bot <yoshi-automation@google.com>

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -42,17 +42,18 @@ jobs:
           pip --version  
       - run: ./google-api-java-client-services/.github/workflows/generate.sh ${{ matrix.service }}
       - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
-        token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-        commit-message: ${{ env.MESSAGE }}
-        committer: ${{ env.AUTHOR }}
-        author: ${{ env.AUTHOR }}
-        branch: regenerate-${{ matrix.service }}
-        title: ${{ env.MESSAGE }}
-        body: 'Generated in GitHub action: https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/workflows/codegen.yaml'
-        add-paths: 'google-api-java-client-services/clients/google-api-services-${{ matrix.service }}'
-        base: main
-        push-to-fork: yoshi-code-bot/google-api-java-client-services
-
         env:
-          - MESSAGE: 'chore: regenerate ${{ matrix.service }} client'
-          - AUTHOR: Yoshi Code Bot <yoshi-automation@google.com>
+          MESSAGE: 'chore: regenerate ${{ matrix.service }} client'
+          AUTHOR: Yoshi Code Bot <yoshi-automation@google.com>
+        with: 
+          token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+          commit-message: ${{ env.MESSAGE }}
+          committer: ${{ env.AUTHOR }}
+          author: ${{ env.AUTHOR }}
+          branch: regenerate-${{ matrix.service }}
+          title: ${{ env.MESSAGE }}
+          body: 'Generated in GitHub action: https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/workflows/codegen.yaml'
+          add-paths: 'google-api-java-client-services/clients/google-api-services-${{ matrix.service }}'
+          base: main
+          push-to-fork: yoshi-code-bot/google-api-java-client-services
+        

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -27,13 +27,13 @@ jobs:
         with:
           fetch-depth: 1
           path: google-api-java-client-services
-          token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
       - uses: actions/checkout@v2
         with:
           repository: googleapis/discovery-artifact-manager
           fetch-depth: 1
           path: discovery-artifact-manager
-          token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
       - uses: actions/setup-python@v5
         with:
           python-version: 3.8.18
@@ -47,7 +47,7 @@ jobs:
         shell: bash
         working-directory: google-api-java-client-services
         env:
-          GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
           SERVICE: ${{ matrix.service }}
           AUTHOR: "Cloud Java Bot <cloud-java-bot@google.com>"
           BASE_REPO: "${{ github.repository }}"

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -27,6 +27,7 @@ jobs:
         with:
           fetch-depth: 1
           path: google-api-java-client-services
+          token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
       - uses: actions/checkout@v2
         with:
           repository: googleapis/discovery-artifact-manager
@@ -45,20 +46,16 @@ jobs:
         shell: bash
         working-directory: google-api-java-client-services
         env:
-          GH_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
           SERVICE: ${{ matrix.service }}
-          AUTHOR: "Yoshi Code Bot <yoshi-automation@google.com>"
-          FORK_REPO: "yoshi-code-bot/google-api-java-client-services"
+          AUTHOR: "Cloud Java Bot <cloud-java-bot@google.com>"
           BASE_REPO: "${{ github.repository }}"
         run: |
           set -ex
 
           # 1. Setup Identity
-          git config user.name "Yoshi Code Bot"
-          git config user.email "yoshi-automation@google.com"
-
-          # 2. Add and Fetch Fork
-          git remote add fork "https://x-access-token:${GH_TOKEN}@github.com/${FORK_REPO}.git"
+          git config user.name "Cloud Java Bot"
+          git config user.email "cloud-java-bot@google.com"
           
           # 3. Create Branch
           BRANCH="regenerate-${SERVICE}"
@@ -76,15 +73,11 @@ jobs:
           fi
 
           git commit -m "$MESSAGE"
-          git push fork "$BRANCH" --force
-
-          # 6. Create PR using GitHub CLI
-          # Note: --head needs 'owner:branch' format when pushing from a fork
-          FORK_OWNER=$(echo "$FORK_REPO" | cut -d'/' -f1)
+          git push origin "$BRANCH" --force
           
           gh pr create \
             --repo "$BASE_REPO" \
-            --head "${FORK_OWNER}:${BRANCH}" \
+            --head "${BRANCH}" \
             --base "main" \
             --title "$MESSAGE" \
             --body "Generated in GitHub action: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -33,6 +33,7 @@ jobs:
           repository: googleapis/discovery-artifact-manager
           fetch-depth: 1
           path: discovery-artifact-manager
+          token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
       - uses: actions/setup-python@v5
         with:
           python-version: 3.8.18

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -65,7 +65,7 @@ jobs:
           git checkout -b "$BRANCH"
 
           # 4. Stage specific files (Large commit handling)
-          TARGET_PATH="google-api-java-client-services/clients/google-api-services-${SERVICE}"
+          TARGET_PATH="clients/google-api-services-${SERVICE}"
           git add "$TARGET_PATH"
 
           # 5. Commit & Push


### PR DESCRIPTION
Context: b/489346278

Fixes tree size limit that blocks compute from being pushed
 - https://github.com/googleapis/google-api-java-client-services/actions/runs/22931225574/job/66553039208

code-suggester uses the GH API directly instead of the typical clone, push, open PR flow. That direct API hit causes a 422 for Compute due to the size of the _tree_.

Approach: use an inline bash script that commits locally and pushes to a branch in this repo (not a fork).