### PR TITLE
build: use 4 batches of 100 services

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -1,13 +1,13 @@
 on:
   schedule:
-  # Runs at 12:18, 1:18 and 2:18.
+  # Runs at 12:18, 1:18, 2:18 and 3:18.
   # See https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule
-  - cron: '18 0-2 * * *'
+  - cron: '18 0-3 * * *'
   workflow_dispatch:
     inputs:
       batch_index:
         type: number
-        description: Index of the batch ([0-2]). You must call this workflow one time per index in order to confirm the generation in all the jobs.
+        description: Index of the batch ([0-3]). You must call this workflow one time per index in order to confirm the generation in all the jobs.
 
 name: codegen
 jobs:
@@ -23,7 +23,7 @@ jobs:
         with:
           script: |
             console.log('checking size of services')
-            const MAX_SERVICE_SIZE = 300 // 00:18 to 02:18 implies 3 batches of size 100
+            const MAX_SERVICE_SIZE = 400 // 00:18 to 03:18 implies 4 batches of size 100
             const services = ${{ needs.discovery.outputs.services }}
             if (services.length > MAX_SERVICE_SIZE) {
               throw new Error(`Total services (${services.length}) exceed limit of ${MAX_SERVICE_SIZE}`)


### PR DESCRIPTION
Fixes the following:

```
checking size of services
Error: Total services (303) exceed limit of 300
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v5/dist/index.js:4888:16), <anonymous>:7:9)
```

https://github.com/googleapis/google-api-java-client-services/actions/runs/25089385991/job/73512013375