### PR TITLE
chore(actions): address zizmor findings

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 on:
   schedule:
   # Runs daily at 00:18 UTC.
@@ -7,14 +10,14 @@ on:
 name: codegen
 jobs:
   discovery:
-    uses: googleapis/discovery-artifact-manager/.github/workflows/list-services.yml@master
+    uses: googleapis/discovery-artifact-manager/.github/workflows/list-services.yml@master # zizmor: ignore[unpinned-uses]
   batch:
     runs-on: 'ubuntu-24.04'
     needs: discovery
     outputs:
       batches: ${{ steps.chunk.outputs.result }}
     steps:
-      - uses: actions/github-script@v5
+      - uses: actions/github-script@211cb3fefb35a799baa5156f9321bb774fe56294 # v5
         id: chunk
         with:
           script: |
@@ -34,9 +37,9 @@ jobs:
               indices
             }
   generate:
-    uses: googleapis/google-api-java-client-services/.github/workflows/generate.yaml@main
+    uses: googleapis/google-api-java-client-services/.github/workflows/generate.yaml@main # zizmor: ignore[unpinned-uses,secrets-inherit]
     needs: batch
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -22,19 +25,23 @@ jobs:
       matrix:
         service: ${{fromJson(inputs.services)}}
     steps:
-      - run: echo generating ${{ matrix.service }}
-      - uses: actions/checkout@v2
+      - run: echo generating ${MATRIX_SERVICE}
+        env:
+          MATRIX_SERVICE: ${{ matrix.service }}
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           fetch-depth: 1
           path: google-api-java-client-services
           token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-      - uses: actions/checkout@v2
+          persist-credentials: false
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: googleapis/discovery-artifact-manager
           fetch-depth: 1
           path: discovery-artifact-manager
           token: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-      - uses: actions/setup-python@v5
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.8.18
       - run: |
@@ -42,8 +49,10 @@ jobs:
           python3 --version
           pip install pip==21.3.1
           pip --version  
-      - run: ./google-api-java-client-services/.github/workflows/generate.sh ${{ matrix.service }}
-      - uses: googleapis/code-suggester@v5
+      - run: ./google-api-java-client-services/.github/workflows/generate.sh ${MATRIX_SERVICE}
+        env:
+          MATRIX_SERVICE: ${{ matrix.service }}
+      - uses: googleapis/code-suggester@f9fef85aa02459e30e62526abe950341cbbd768b # v5
         env:
           ACCESS_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
         with:

--- a/.github/workflows/update-root-readme.yaml
+++ b/.github/workflows/update-root-readme.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 on:
   schedule:
   # Runs at 03:00 am.
@@ -9,10 +12,11 @@ jobs:
   update:
     runs-on: 'ubuntu-24.04'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           fetch-depth: 1
           path: google-api-java-client-services
+          persist-credentials: false
       - run: |
           sudo apt update
           sudo apt install python3
@@ -21,7 +25,7 @@ jobs:
           python3 get-pip.py
           python3 -m pip install --require-hashes -r ./google-api-java-client-services/.github/workflows/requirements.txt
       - run: python3 ./google-api-java-client-services/.github/workflows/update-root-readme.py
-      - uses: googleapis/code-suggester@v2 # takes the changes from git directory
+      - uses: googleapis/code-suggester@9222591646c050504e4a341ab8418cbfb5f619e1 # v2
         env:
           ACCESS_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
         with:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 on:
   schedule:
     # Runs at 04:00 am
@@ -46,13 +49,14 @@ jobs:
       failed_libraries_y: ${{ steps.compile.outputs.failed_libraries_y }}
       failed_libraries_z: ${{ steps.compile.outputs.failed_libraries_z }}
     steps:
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           distribution: temurin
           java-version: 8
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           path: google-api-java-client-services
+          persist-credentials: false
 
       - id: compile
         working-directory: google-api-java-client-services


### PR DESCRIPTION
This PR is an auto-generated attempt to address zizmor findings. It may not catch everything, and should be reviewed by repository owners.

These changes were generated by running `zizmor --fix=all --gh-token=$(gh auth token) ./.github/workflows`, and then applying some fixes for any remaining issues reported by zizmor. See go/github-zizmor-help for instructions to install and run.

If this PR is unhelpful, feel free to close the PR and address separately. If it is helpful, feel free to approve and merge, or edit/modify as needed to get it to the right state. Repository owners must ultimately ensure compliance by 2026-07-13. The purpose of this PR is to provide some assistance with achieving that as a first pass. This will become a blocking check for new changes to github workflows on 2026-07-13 within the `googleapis` org.

There may be some ignored findings (with the comment `# zizmor: ignore[...]`), which you may fix if feasible.
